### PR TITLE
Refactor: split up binding.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ instance that you want to access, and make a series of calls that return progres
 lower level information from OpsRamp. For clarity in these end-user instructions I have omitted several Python
 classes that are internal implementation detail in the module and not intended for direct use by external callers.
 
+Here's an illustration of a simple use of the binding. See examples.py for a much more comprehensive one.
+```
+import opsramp.binding
+
+ormp = opsramp.binding.connect(OPSRAMP_URL, KEY, SECRET)
+cfg = ormp.config()
+print('alert types', cfg.get_alert_types())
+```
+
+import opsramp.binding
+
 - def connect(url, key, secret) _returns an instance of the class Opsramp that is connected to the specified API endpoint_
   This function posts a login request to the specified endpoint URL using the key and secret given. This post
   returns an access token, which the function uses to construct an Opsramp object and returns that.
@@ -125,6 +136,8 @@ classes that are internal implementation detail in the module and not intended f
 - class Opsramp(url, token) _an object representing the complete API tree of one OpsRamp instance_
   - config() -> returns a GlobalConfig object that can be used to access global settings for this OpsRamp instance.
   - tenant(uuid) -> returns a Tenant object representing the API subtree for one specific tenant.
+
+import opsramp.globalconfig
 
 - class GlobalConfig() _read-only access to global settings on this OpsRamp instance_
   - get\_alert\_types() -> returns a list of the global alert types that are defined on this OpsRamp instance.
@@ -135,6 +148,8 @@ classes that are internal implementation detail in the module and not intended f
   - get\_nocs() -> a list of dicts each describing one NOC known to this OpsRamp instance.
   - get\_device\_types() -> a list of dicts each describing device type known to this OpsRamp instance.
 
+import opsramp.tenant
+
 - class Tenant(uuid) _the API subtree for one specific tenant_
   - get\_alert\_script() -> Returns a string containing the appropriate Python script to run on a Linux node
   to install the OpsRamp agent there and connect it to this Tenant. This text contains the tenant's access keys
@@ -144,12 +159,16 @@ classes that are internal implementation detail in the module and not intended f
   - monitoring() -> returns a Monitoring object representing all monitoring information for this Tenant.
   - rba() -> returns an Rba object representing all runbook automation information for this Tenant.
 
+import opsramp.monitoring
+
 - class Monitoring() _the monitoring information subtree for one specific Tenant_
   - templates() -> returns a Templates object representing the set of monitoring templates on this Tenant.
 
 - class Templates() _the set of monitoring templates for one Tenant_
   - search(pattern) -> returns a list of templates that match the pattern. See the OpsRamp API docs for details
   on the format of the pattern string.
+
+import opsramp.rba
 
 - class Rba() _the runbook automation subtree of one specific Tenant_
   - get\_categories() -> Return a list of all the script categories in this subtree.
@@ -172,6 +191,8 @@ classes that are internal implementation detail in the module and not intended f
   a Python dict describing a proposed new script. Some of the parameters are only applicable on Linux,
   some only on Windows, and the function contains `assert` statements to flag violations of those rules.
 
+import opsramp.msp
+
 - class Clients() _the subtree containing all clients_
   This call is only supported on Tenants that are at MSP or Partner level or higher because a Client
   cannot contain other clients.
@@ -186,6 +207,8 @@ classes that are internal implementation detail in the module and not intended f
 
 - class Client() _a single client_
   - get() -> returns the definition of this client as a Python dict. See the OpsRamp API docs for detailed contents.
+
+import opsramp.devmgmt
 
 - class Policies() _the policies subtree of one specific Tenant_
   - get\_list() -> returns a list of dicts, each containing a single policy definition.

--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+#
+# A minimal Python language binding for the OpsRamp REST API.
+#
+# base.py
+# Containing various base classes used in other parts of the library
+# but not intended for direct use by callers.
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import requests
+
+
+class PathTracker(object):
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.prefix = ''
+        self.stack = []
+
+    def __str__(self):
+        return '%s "%s" %s' % (str(type(self)), self.prefix, self.stack)
+
+    def clone(self):
+        new1 = PathTracker()
+        new1.prefix = self.prefix
+        new1.stack = self.stack
+        return new1
+
+    def cd(self, path):
+        # no support for '..' right now, maybe in the future
+        if path[0] == '/':
+            self.prefix = path
+        else:
+            self.prefix += '/' + path
+        self.prefix = self.prefix.strip('/')
+        return self.prefix
+
+    def pushd(self, path):
+        self.stack.append(self.prefix)
+        return self.cd(path)
+
+    def popd(self):
+        self.prefix = self.stack.pop()
+        return self.prefix
+
+    def fullpath(self, suffix=''):
+        if len(suffix) > 0 and suffix[0] == '/':
+            retval = suffix
+        else:
+            retval = ''
+            if len(self.prefix) > 0:
+                retval += '/' + self.prefix
+            if len(suffix) > 0:
+                retval += '/' + suffix
+        return retval
+
+
+class ApiObject(object):
+    def __init__(self, url, auth, tracker=None):
+        self.baseurl = url.rstrip('/')
+        self.auth = auth
+        if tracker:
+            self.tracker = tracker
+        else:
+            self.tracker = PathTracker()
+
+    def __str__(self):
+        return '%s "%s" "%s"' % (
+            str(type(self)), self.baseurl, self.tracker.fullpath()
+        )
+
+    def clone(self):
+        new1 = ApiObject(self.baseurl, self.auth, self.tracker.clone())
+        return new1
+
+    def cd(self, path):
+        return self.tracker.cd(path)
+
+    def pushd(self, path):
+        return self.tracker.pushd(path)
+
+    def popd(self):
+        return self.tracker.popd()
+
+    def chroot(self, suffix=''):
+        suffix = self.tracker.fullpath(suffix)
+        if suffix:
+            self.baseurl += suffix
+            self.tracker.reset()
+        return ''
+
+    def compute_url(self, suffix=''):
+        retval = self.baseurl
+        suffix = self.tracker.fullpath(suffix)
+        if suffix:
+            retval += suffix
+        return retval.rstrip('/')
+
+    def prep_headers(self, headers):
+        if not headers:
+            return self.auth
+        hdr = {}
+        hdr.update(self.auth)
+        hdr.update(headers)
+        return hdr
+
+    @staticmethod
+    def process_result(url, resp):
+        if resp.status_code != requests.codes.OK:
+            msg = '%s %s %s' % (resp, url, resp.content)
+            raise RuntimeError(msg)
+        try:
+            return resp.json()
+        except: # noqa
+            return resp.text
+
+    def get(self, suffix='', headers={}):
+        url = self.compute_url(suffix)
+        hdr = self.prep_headers(headers)
+        resp = requests.get(url, headers=hdr)
+        return self.process_result(url, resp)
+
+    def post(self, suffix='', headers={}, data=None, json=None):
+        url = self.compute_url(suffix)
+        hdr = self.prep_headers(headers)
+        resp = requests.post(url, headers=hdr, data=data, json=json)
+        return self.process_result(url, resp)
+
+    def put(self, suffix='', headers={}, data=None, json=None):
+        url = self.compute_url(suffix)
+        hdr = self.prep_headers(headers)
+        resp = requests.put(url, headers=hdr, data=data, json=json)
+        return self.process_result(url, resp)
+
+    def delete(self, suffix='', headers={}):
+        url = self.compute_url(suffix)
+        hdr = self.prep_headers(headers)
+        resp = requests.delete(url, headers=hdr)
+        return self.process_result(url, resp)
+
+
+class ApiWrapper(object):
+    def __init__(self, apiobject, suffix=''):
+        self.api = apiobject.clone()
+        if suffix:
+            self.api.chroot(suffix)
+
+    def __str__(self):
+        return '%s %s' % (str(type(self)), self.api)

--- a/opsramp/binding.py
+++ b/opsramp/binding.py
@@ -23,10 +23,7 @@ from __future__ import print_function
 
 from opsramp.base import ApiObject, ApiWrapper
 from opsramp.globalconfig import GlobalConfig
-from opsramp.rba import Rba
-from opsramp.monitoring import Monitoring
-from opsramp.msp import Clients
-from opsramp.devmgmt import Policies
+from opsramp.tenant import Tenant
 
 
 def connect(url, key, secret):
@@ -61,33 +58,3 @@ class Opsramp(ApiWrapper):
 
     def tenant(self, name):
         return Tenant(self, name)
-
-
-class Tenant(ApiWrapper):
-    def __init__(self, parent, uuid):
-        super(Tenant, self).__init__(parent.api, 'tenants/%s' % uuid)
-        self.uuid = uuid
-
-    def is_client(self):
-        return self.uuid[:7] == 'client_'
-
-    def rba(self):
-        return Rba(self)
-
-    def monitoring(self):
-        return Monitoring(self)
-
-    def clients(self):
-        assert not self.is_client()
-        return Clients(self)
-
-    def get_alerts(self, searchpattern):
-        return self.api.get('/alerts/search?queryString=%s' % searchpattern)
-
-    def get_agent_script(self):
-        assert self.is_client()
-        hdr = {'Accept': 'application/octet-stream,application/xml'}
-        return self.api.get('agents/deployAgentsScript', headers=hdr)
-
-    def policies(self):
-        return Policies(self)

--- a/opsramp/binding.py
+++ b/opsramp/binding.py
@@ -23,6 +23,7 @@ from __future__ import print_function
 import base64
 
 from opsramp.base import ApiObject, ApiWrapper
+from opsramp.globalconfig import GlobalConfig
 
 
 def connect(url, key, secret):
@@ -57,41 +58,6 @@ class Opsramp(ApiWrapper):
 
     def tenant(self, name):
         return Tenant(self, name)
-
-
-class GlobalConfig(ApiWrapper):
-    def __init__(self, parent):
-        super(GlobalConfig, self).__init__(parent.api, '')
-
-    def get_alert_types(self):
-        return self.api.get('/alertTypes')
-
-    def get_countries(self):
-        return self.api.get('/cfg/countries')
-
-    def get_timezones(self):
-        return self.api.get('/cfg/timezones')
-
-    def get_alert_technologies(self):
-        return self.api.get('/cfg/alertTechnologies')
-
-    def get_channels(self):
-        return self.api.get('/cfg/tenants/channels')
-
-    def get_nocs(self):
-        # Bizarrely this API call throws a 500 error if there are
-        # no NOCs defined. Handle it gracefully.
-        try:
-            retval = self.api.get('/cfg/tenants/nocs')
-        except RuntimeError as e:
-            if '"code":"0005"' in str(e):
-                retval = []
-            else:
-                raise
-        return retval
-
-    def get_device_types(self):
-        return self.api.get('/cfg/devices/types')
 
 
 class Tenant(ApiWrapper):

--- a/opsramp/binding.py
+++ b/opsramp/binding.py
@@ -26,6 +26,7 @@ from opsramp.globalconfig import GlobalConfig
 from opsramp.rba import Rba
 from opsramp.monitoring import Monitoring
 from opsramp.msp import Clients
+from opsramp.devmgmt import Policies
 
 
 def connect(url, key, secret):
@@ -90,37 +91,3 @@ class Tenant(ApiWrapper):
 
     def policies(self):
         return Policies(self)
-
-
-class Policies(ApiWrapper):
-    def __init__(self, parent):
-        super(Policies, self).__init__(parent.api, 'policies/management')
-
-    def get_list(self):
-        return self.api.get()
-
-    def search(self, pattern=''):
-        return self.api.get('/search?name=%s' % pattern)
-
-    def policy(self, uuid):
-        return Policy(self, uuid)
-
-    def create_policy(self, policy_definition):
-        return self.api.post('', json=policy_definition)
-
-    def update_policy(self, policy_definition):
-        return self.api.put('', json=policy_definition)
-
-
-class Policy(ApiWrapper):
-    def __init__(self, parent, uuid):
-        super(Policy, self).__init__(parent.api, '%s' % uuid)
-
-    def get(self):
-        return self.api.get()
-
-    def run(self):
-        return self.api.get('/action/run')
-
-    def delete(self):
-        return self.api.delete()

--- a/opsramp/binding.py
+++ b/opsramp/binding.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 from opsramp.base import ApiObject, ApiWrapper
 from opsramp.globalconfig import GlobalConfig
 from opsramp.rba import Rba
+from opsramp.monitoring import Monitoring
 
 
 def connect(url, key, secret):
@@ -88,25 +89,6 @@ class Tenant(ApiWrapper):
 
     def policies(self):
         return Policies(self)
-
-
-class Monitoring(ApiWrapper):
-    def __init__(self, parent):
-        super(Monitoring, self).__init__(parent.api, 'monitoring')
-
-    def templates(self):
-        return Templates(self)
-
-
-class Templates(ApiWrapper):
-    def __init__(self, parent):
-        super(Templates, self).__init__(parent.api, 'templates')
-
-    def search(self, pattern=''):
-        suffix = '/search'
-        if pattern:
-            suffix += '?' + pattern
-        return self.api.get(suffix)
 
 
 class Clients(ApiWrapper):

--- a/opsramp/binding.py
+++ b/opsramp/binding.py
@@ -25,6 +25,7 @@ from opsramp.base import ApiObject, ApiWrapper
 from opsramp.globalconfig import GlobalConfig
 from opsramp.rba import Rba
 from opsramp.monitoring import Monitoring
+from opsramp.msp import Clients
 
 
 def connect(url, key, secret):
@@ -89,29 +90,6 @@ class Tenant(ApiWrapper):
 
     def policies(self):
         return Policies(self)
-
-
-class Clients(ApiWrapper):
-    def __init__(self, parent):
-        super(Clients, self).__init__(parent.api, 'clients')
-
-    def get_list(self):
-        return self.api.get('/minimal')
-
-    def client(self, uuid):
-        return Client(self, uuid)
-
-    def create_client(self, client_definition):
-        return self.api.post('', json=client_definition)
-
-
-class Client(ApiWrapper):
-    def __init__(self, parent, uuid):
-        assert uuid[:7] == 'client_'
-        super(Client, self).__init__(parent.api, '%s' % uuid)
-
-    def get(self):
-        return self.api.get()
 
 
 class Policies(ApiWrapper):

--- a/opsramp/binding.py
+++ b/opsramp/binding.py
@@ -20,10 +20,10 @@
 # limitations under the License.
 
 from __future__ import print_function
-import base64
 
 from opsramp.base import ApiObject, ApiWrapper
 from opsramp.globalconfig import GlobalConfig
+from opsramp.rba import Rba
 
 
 def connect(url, key, secret):
@@ -88,141 +88,6 @@ class Tenant(ApiWrapper):
 
     def policies(self):
         return Policies(self)
-
-
-class Rba(ApiWrapper):
-    def __init__(self, parent):
-        super(Rba, self).__init__(parent.api, 'rba')
-
-    def category(self, uuid):
-        return Category(self, uuid)
-
-    def get_categories(self):
-        return self.api.get('/categories')
-
-    def create_category(self, name, parent_uuid=None):
-        jjj = {'name': name}
-        if parent_uuid:
-            jjj['parent'] = parent_uuid
-        return self.api.post('/categories', json=jjj)
-
-
-class Category(ApiWrapper):
-    def __init__(self, parent, uuid):
-        super(Category, self).__init__(parent.api, 'categories/%s' % uuid)
-
-    def script(self, uuid):
-        return Script(self, uuid)
-
-    def get_scripts(self):
-        return self.api.get('/scripts')
-
-    def create_script(self, script_definition):
-        return self.api.post('/scripts', json=script_definition)
-
-
-class Script(ApiWrapper):
-    def __init__(self, parent, uuid):
-        super(Script, self).__init__(parent.api, 'scripts/%s' % uuid)
-
-    def get(self):
-        return self.api.get()
-
-    # Returns a string containing a base64 encoded version of the
-    # content of the specified file. It was quite finicky to come
-    # up with a method that works on both Python 2 and 3 so please
-    # don't modify this, or test carefully if you do.
-    @staticmethod
-    def encode_payload(fname):
-        with open(fname, 'rb') as f:
-            content = base64.b64encode(f.read())
-        return content.decode()
-
-    # A helper function for use with mkparameter & mkscript.
-    @staticmethod
-    def mkattachment(name, payload):
-        assert name
-        return {
-            'name': name,
-            'file': payload
-        }
-
-    # Returns a Python dict that defines one parameter of a script.
-    @staticmethod
-    def mkparameter(name, description, datatype,
-                    optional=False, default=None):
-        assert name
-        assert description
-        assert datatype
-        if optional:
-            assert default is not None
-        return {
-            'name': name,
-            'description': description,
-            'dataType': datatype,
-            'type': 'OPTIONAL' if optional else 'REQUIRED',
-            'defaultValue': default
-        }
-
-    # Returns a Python dict that defines a new RBA script. Intended
-    # for use with Category.create_script() it also asserts that
-    # certain rules are being complied with in the script definition.
-    @staticmethod
-    def mkscript(name, description, platforms, execution_type, payload,
-                 parameters=[],
-                 script_name=None,
-                 install_timeout=0,
-                 registry_path=None,
-                 registry_value=None,
-                 process_name=None,
-                 service_name=None,
-                 output_directory=None,
-                 output_file=None):
-        if execution_type not in ('DOWNLOAD', 'EXE', 'MSI'):
-            assert not output_directory
-            assert not output_file
-        if execution_type == 'COMMAND':
-            payload_key = 'command'
-            payload_value = payload
-        else:
-            payload_key = 'attachment'
-            payload_value = Script.mkattachment(script_name, payload)
-
-        # fields that are always present.
-        retval = {
-            'name': name,
-            'description': description,
-            'platforms': platforms,
-            'executionType': execution_type,
-            payload_key: payload_value
-        }
-
-        # optional ones.
-        if parameters:
-            retval['parameters'] = parameters
-
-        if install_timeout:
-            retval['installTimeout'] = install_timeout
-
-        if 'WINDOWS' not in platforms:
-            assert not registry_path
-            assert not registry_value
-        else:
-            if registry_path:
-                retval['registryPath'] = registry_path
-                if registry_value:
-                    retval['registryValue'] = registry_value
-
-        if 'LINUX' not in platforms:
-            assert not process_name
-            assert not service_name
-        else:
-            if process_name:
-                retval['processName'] = process_name
-            if service_name:
-                retval['serviceName'] = service_name
-
-        return retval
 
 
 class Monitoring(ApiWrapper):

--- a/opsramp/devmgmt.py
+++ b/opsramp/devmgmt.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+#
+# A minimal Python language binding for the OpsRamp REST API.
+#
+# devmgmt.py
+# Device management classes.
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+from opsramp.base import ApiWrapper
+
+
+class Policies(ApiWrapper):
+    def __init__(self, parent):
+        super(Policies, self).__init__(parent.api, 'policies/management')
+
+    def get_list(self):
+        return self.api.get()
+
+    def search(self, pattern=''):
+        return self.api.get('/search?name=%s' % pattern)
+
+    def policy(self, uuid):
+        return Policy(self, uuid)
+
+    def create_policy(self, policy_definition):
+        return self.api.post('', json=policy_definition)
+
+    def update_policy(self, policy_definition):
+        return self.api.put('', json=policy_definition)
+
+
+class Policy(ApiWrapper):
+    def __init__(self, parent, uuid):
+        super(Policy, self).__init__(parent.api, '%s' % uuid)
+
+    def get(self):
+        return self.api.get()
+
+    def run(self):
+        return self.api.get('/action/run')
+
+    def delete(self):
+        return self.api.delete()

--- a/opsramp/examples.py
+++ b/opsramp/examples.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import os
 
 import opsramp.binding
+import opsramp.rba
 
 
 CATEGORY_NAME = 'Testing 123'
@@ -107,14 +108,14 @@ def main():
 
     # Create a new RBA script in this category, with one parameter. You can
     # see from the "payload" that this gets passed to the script as $1
-    p1 = opsramp.binding.Script.mkparameter(
+    p1 = opsramp.rba.Script.mkparameter(
         name='venue',
         description='Where am I today?',
         datatype='STRING'
     )
     print('Parameter definition struct')
     print(p1)
-    s1 = opsramp.binding.Script.mkscript(
+    s1 = opsramp.rba.Script.mkscript(
         name='Hello <venue>',
         description='Stereotypical rock star intro',
         platforms=['LINUX'],

--- a/opsramp/globalconfig.py
+++ b/opsramp/globalconfig.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+#
+# A minimal Python language binding for the OpsRamp REST API.
+#
+# globalconfig.py
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+from opsramp.base import ApiWrapper
+
+
+class GlobalConfig(ApiWrapper):
+    def __init__(self, parent):
+        super(GlobalConfig, self).__init__(parent.api, '')
+
+    def get_alert_types(self):
+        return self.api.get('/alertTypes')
+
+    def get_countries(self):
+        return self.api.get('/cfg/countries')
+
+    def get_timezones(self):
+        return self.api.get('/cfg/timezones')
+
+    def get_alert_technologies(self):
+        return self.api.get('/cfg/alertTechnologies')
+
+    def get_channels(self):
+        return self.api.get('/cfg/tenants/channels')
+
+    def get_nocs(self):
+        # Bizarrely this API call throws a 500 error if there are
+        # no NOCs defined. Handle it gracefully.
+        try:
+            retval = self.api.get('/cfg/tenants/nocs')
+        except RuntimeError as e:
+            if '"code":"0005"' in str(e):
+                retval = []
+            else:
+                raise
+        return retval
+
+    def get_device_types(self):
+        return self.api.get('/cfg/devices/types')

--- a/opsramp/monitoring.py
+++ b/opsramp/monitoring.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+#
+# A minimal Python language binding for the OpsRamp REST API.
+#
+# monitoring.py
+# Classes related to monitoring templates and similar things.
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+from opsramp.base import ApiWrapper
+
+
+class Monitoring(ApiWrapper):
+    def __init__(self, parent):
+        super(Monitoring, self).__init__(parent.api, 'monitoring')
+
+    def templates(self):
+        return Templates(self)
+
+
+class Templates(ApiWrapper):
+    def __init__(self, parent):
+        super(Templates, self).__init__(parent.api, 'templates')
+
+    def search(self, pattern=''):
+        suffix = '/search'
+        if pattern:
+            suffix += '?' + pattern
+        return self.api.get(suffix)

--- a/opsramp/msp.py
+++ b/opsramp/msp.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#
+# A minimal Python language binding for the OpsRamp REST API.
+#
+# msp.py
+# Classes related to partner-level actions.
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+from opsramp.base import ApiWrapper
+
+
+class Clients(ApiWrapper):
+    def __init__(self, parent):
+        super(Clients, self).__init__(parent.api, 'clients')
+
+    def get_list(self):
+        return self.api.get('/minimal')
+
+    def client(self, uuid):
+        return Client(self, uuid)
+
+    def create_client(self, client_definition):
+        return self.api.post('', json=client_definition)
+
+
+class Client(ApiWrapper):
+    def __init__(self, parent, uuid):
+        assert uuid[:7] == 'client_'
+        super(Client, self).__init__(parent.api, '%s' % uuid)
+
+    def get(self):
+        return self.api.get()

--- a/opsramp/rba.py
+++ b/opsramp/rba.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+#
+# A minimal Python language binding for the OpsRamp REST API.
+#
+# rba.py
+# Runbook Automation related classes
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import base64
+
+from opsramp.base import ApiWrapper
+
+
+class Rba(ApiWrapper):
+    def __init__(self, parent):
+        super(Rba, self).__init__(parent.api, 'rba')
+
+    def category(self, uuid):
+        return Category(self, uuid)
+
+    def get_categories(self):
+        return self.api.get('/categories')
+
+    def create_category(self, name, parent_uuid=None):
+        jjj = {'name': name}
+        if parent_uuid:
+            jjj['parent'] = parent_uuid
+        return self.api.post('/categories', json=jjj)
+
+
+class Category(ApiWrapper):
+    def __init__(self, parent, uuid):
+        super(Category, self).__init__(parent.api, 'categories/%s' % uuid)
+
+    def script(self, uuid):
+        return Script(self, uuid)
+
+    def get_scripts(self):
+        return self.api.get('/scripts')
+
+    def create_script(self, script_definition):
+        return self.api.post('/scripts', json=script_definition)
+
+
+class Script(ApiWrapper):
+    def __init__(self, parent, uuid):
+        super(Script, self).__init__(parent.api, 'scripts/%s' % uuid)
+
+    def get(self):
+        return self.api.get()
+
+    # Returns a string containing a base64 encoded version of the
+    # content of the specified file. It was quite finicky to come
+    # up with a method that works on both Python 2 and 3 so please
+    # don't modify this, or test carefully if you do.
+    @staticmethod
+    def encode_payload(fname):
+        with open(fname, 'rb') as f:
+            content = base64.b64encode(f.read())
+        return content.decode()
+
+    # A helper function for use with mkparameter & mkscript.
+    @staticmethod
+    def mkattachment(name, payload):
+        assert name
+        return {
+            'name': name,
+            'file': payload
+        }
+
+    # Returns a Python dict that defines one parameter of a script.
+    @staticmethod
+    def mkparameter(name, description, datatype,
+                    optional=False, default=None):
+        assert name
+        assert description
+        assert datatype
+        if optional:
+            assert default is not None
+        return {
+            'name': name,
+            'description': description,
+            'dataType': datatype,
+            'type': 'OPTIONAL' if optional else 'REQUIRED',
+            'defaultValue': default
+        }
+
+    # Returns a Python dict that defines a new RBA script. Intended
+    # for use with Category.create_script() it also asserts that
+    # certain rules are being complied with in the script definition.
+    @staticmethod
+    def mkscript(name, description, platforms, execution_type, payload,
+                 parameters=[],
+                 script_name=None,
+                 install_timeout=0,
+                 registry_path=None,
+                 registry_value=None,
+                 process_name=None,
+                 service_name=None,
+                 output_directory=None,
+                 output_file=None):
+        if execution_type not in ('DOWNLOAD', 'EXE', 'MSI'):
+            assert not output_directory
+            assert not output_file
+        if execution_type == 'COMMAND':
+            payload_key = 'command'
+            payload_value = payload
+        else:
+            payload_key = 'attachment'
+            payload_value = Script.mkattachment(script_name, payload)
+
+        # fields that are always present.
+        retval = {
+            'name': name,
+            'description': description,
+            'platforms': platforms,
+            'executionType': execution_type,
+            payload_key: payload_value
+        }
+
+        # optional ones.
+        if parameters:
+            retval['parameters'] = parameters
+
+        if install_timeout:
+            retval['installTimeout'] = install_timeout
+
+        if 'WINDOWS' not in platforms:
+            assert not registry_path
+            assert not registry_value
+        else:
+            if registry_path:
+                retval['registryPath'] = registry_path
+                if registry_value:
+                    retval['registryValue'] = registry_value
+
+        if 'LINUX' not in platforms:
+            assert not process_name
+            assert not service_name
+        else:
+            if process_name:
+                retval['processName'] = process_name
+            if service_name:
+                retval['serviceName'] = service_name
+
+        return retval

--- a/opsramp/tenant.py
+++ b/opsramp/tenant.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+#
+# A minimal Python language binding for the OpsRamp REST API.
+#
+# tenant.py
+# Classes dealing directly with OpsRamp Tenants.
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+from opsramp.base import ApiWrapper
+import opsramp.rba
+import opsramp.monitoring
+import opsramp.msp
+import opsramp.devmgmt
+
+
+class Tenant(ApiWrapper):
+    def __init__(self, parent, uuid):
+        super(Tenant, self).__init__(parent.api, 'tenants/%s' % uuid)
+        self.uuid = uuid
+
+    def is_client(self):
+        return self.uuid[:7] == 'client_'
+
+    def rba(self):
+        return opsramp.rba.Rba(self)
+
+    def monitoring(self):
+        return opsramp.monitoring.Monitoring(self)
+
+    def clients(self):
+        assert not self.is_client()
+        return opsramp.msp.Clients(self)
+
+    def policies(self):
+        return opsramp.devmgmt.Policies(self)
+
+    def get_alerts(self, searchpattern):
+        return self.api.get('/alerts/search?queryString=%s' % searchpattern)
+
+    def get_agent_script(self):
+        assert self.is_client()
+        hdr = {'Accept': 'application/octet-stream,application/xml'}
+        return self.api.get('agents/deployAgentsScript', headers=hdr)

--- a/tests/test_pathtracker.py
+++ b/tests/test_pathtracker.py
@@ -17,12 +17,12 @@
 from __future__ import print_function
 import unittest
 
-import opsramp.binding
+from opsramp.base import PathTracker
 
 
 class TrackerTest(unittest.TestCase):
     def setUp(self):
-        self.trkr = opsramp.binding.PathTracker()
+        self.trkr = PathTracker()
         assert 'PathTracker' in str(self.trkr)
 
     def test_cd(self):

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -18,7 +18,7 @@ from __future__ import print_function
 import unittest
 import base64
 
-import opsramp.binding
+from opsramp.rba import Script
 
 
 class StaticsTest(unittest.TestCase):
@@ -26,7 +26,7 @@ class StaticsTest(unittest.TestCase):
         testfile = 'README.md'
         with open(testfile, 'rb') as f:
             expected = f.read()
-        actual64 = opsramp.binding.Script.encode_payload(testfile)
+        actual64 = Script.encode_payload(testfile)
         actual = base64.b64decode(actual64)
         assert actual == expected
 
@@ -35,7 +35,7 @@ class StaticsTest(unittest.TestCase):
             'name': 'whatever.sh',
             'content': 'random stuff'
         }
-        actual = opsramp.binding.Script.mkattachment(
+        actual = Script.mkattachment(
             name=tvalues['name'],
             payload=tvalues['content']
         )
@@ -51,7 +51,7 @@ class StaticsTest(unittest.TestCase):
             'description': 'Where am I today?',
             'type': 'STRING'
         }
-        actual = opsramp.binding.Script.mkparameter(
+        actual = Script.mkparameter(
             name=tvalues['name'],
             description=tvalues['description'],
             datatype=tvalues['type']
@@ -66,7 +66,7 @@ class StaticsTest(unittest.TestCase):
         assert actual == expected
 
     def test_mkscript(self):
-        p1 = opsramp.binding.Script.mkparameter(
+        p1 = Script.mkparameter(
             name='venue',
             description='Where am I today?',
             datatype='STRING'
@@ -79,7 +79,7 @@ class StaticsTest(unittest.TestCase):
             'payload': 'echo "hello $1"',
             'parameters': [p1]
         }
-        actual = opsramp.binding.Script.mkscript(
+        actual = Script.mkscript(
             name=tvalues['name'],
             description=tvalues['description'],
             platforms=tvalues['platforms'],


### PR DESCRIPTION
This library has gotten big enough that keeping everything in one source file has
become unwieldy. Split it up into a file per area of the API.