### PR TITLE
Add Integrations support

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ import opsramp.tenant
   See the OpsRamp API docs for details on the format of the pattern string.
   - monitoring() -> returns a Monitoring object representing all monitoring information for this Tenant.
   - rba() -> returns an Rba object representing all runbook automation information for this Tenant.
+  - integrations() -> returns an Integrations object representing all integrations on this Tenant.
 
 import opsramp.monitoring
 
@@ -234,6 +235,51 @@ import opsramp.devmgmt
   - get() -> returns the definition of this policy as a Python dict. See the OpsRamp API docs for detailed contents.
   - run() -> sends a request to the OpsRamp server to run this policy now. The actual run is asynchronous.
   - delete() -> deletes this policy
+
+import opsramp.integrations
+
+- class Integrations() _the integrations subtree of one specific Tenant_
+  - types() -> Returns an IntegrationTypes object describing all the *types*
+  of integrations that are available to be installed on this Tenant. Each
+  represents a *category* like CUSTOM, AZURE, rather than specific instances
+  of those.
+  - instances() -> Returns an Instances object representing all the actual
+  instances of integrations that are installed on this Tenant. Each has a
+  type field plus a set of configuration values for this specific instance
+  of the type.
+  - create\_instance(type\_name, definition) -> creates a new instance of an
+  integration type on this Tenant. "definition" is a Python dict specifying
+  details of the integration instance that is to be created.
+  Helper functions for creating these dicts will be added later.
+  - _available() -> A synonym for "types()" that I included because that's
+  the name of the API endpoint in OpsRamp that returns this set of data.
+  It took a while to figure out what the returned data means though,
+  so we went with the more obvious name "types" here instead._
+  - _installed() -> A synonym for "instances()" that I included because that's
+  the name of the API endpoint in OpsRamp that returns this set of data.
+  It took a while to figure out what the returned data means though,
+  so we went with the more obvious name "instances" here instead._
+
+- class Types() _a set of integration types_
+  - search(pattern) -> Search for an integration type with a specific name or
+  other attributes. The syntax is defined in the OpsRamp docs.
+
+- class Instances() _a set of instances of integration types_
+  - search(pattern) -> Search for an integration with a specific name or other
+  attributes. The syntax is defined in the OpsRamp docs.
+  - instance(uuid) -> returns an Instance object representing one specific
+  integration instance.
+
+- class SingleInstance() _a single instance of an integration type_
+  - get() -> returns the definition of this specific integration as a Python
+  dict. See the OpsRamp API docs for detailed contents, which varies depending
+  on the integration type.
+  - enable() -> marks this specific instance as "enabled" in OpsRamp.
+  - disable() -> marks this specific instance as "disabled" in OpsRamp.
+  - notifier(definition) -> configures a notifier on this specific instance.
+  "definition" is a Python dict specifying details of the new configuration.
+  The syntax is defined in the OpsRamp docs. Helper functions for creating
+  these dicts will be added later.
 
 ## The API objects and direct REST calls
 

--- a/opsramp/examples.py
+++ b/opsramp/examples.py
@@ -48,6 +48,25 @@ def main():
     # Focus on a specific tenant.
     tenant = ormp.tenant(TENANT_ID)
 
+    print('List the integrations on tenant', TENANT_ID)
+    ints = tenant.integrations()
+    group = ints.types()
+    found = group.search()
+    print(found['totalResults'], 'integration types')
+    for i in found['results']:
+        print(i)
+    group = ints.instances()
+    found = group.search()
+    print(found['totalResults'], 'integration instances')
+    # "found" contains a complete description of each integration but let's
+    # pull them individually anyway and assert that this gives same result.
+    for i in found['results']:
+        print('...', i['id'], i['integration']['id'],
+              '"' + i.get('displayName', '<no name>') + '"')
+        ithis = group.instance(i['id'])
+        direct = ithis.get()
+        assert direct == i
+
     # Retrieve the agent installation script for this client. The string
     # that OpsRamp returns will contain keys for the client so just print
     # its length and first line to show that we got something.

--- a/opsramp/integrations.py
+++ b/opsramp/integrations.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+#
+# A Python language binding for the OpsRamp REST API.
+#
+# integrations.py
+# Classes related to Integrations.
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+from opsramp.base import ApiWrapper
+
+'''
+POST install/{intgld} e.g. CUSTOM
+
+GET installed/search?queryString=
+GET installed/{installedIntgld}
+DELETE installed/{installedIntgld}
+POST installed/{installedIntgld}
+POST installed/{installedIntgld}/notifier
+POST installed/{installedIntgld}/enable
+POST installed/{installedIntgld}/disable
+POST installed/{installedIntgld}/inbound/authentication
+POST installed/{installedIntgld}/mappingAttr
+
+GET available/search?queryString=
+GET available/{intgld}/emailProps/{entityType}
+GET available/{intgld}/mappingAttr/{entityType}
+'''
+
+
+class Integrations(ApiWrapper):
+    def __init__(self, parent):
+        super(Integrations, self).__init__(parent.api, 'integrations')
+
+    def types(self):
+        return Types(self)
+
+    def instances(self):
+        return Instances(self)
+
+    def create_instance(self, type_name, definition):
+        resp = self.api.post('install', type_name, json=definition)
+        return resp
+
+    def available(self):
+        # Compatibility function because this is the name that the
+        # OpsRamp API docs use for this data set.
+        return self.types()
+
+    def installed(self):
+        # Compatibility function because this is the name that the
+        # OpsRamp API docs use for this data set.
+        return self.instances()
+
+
+class Types(ApiWrapper):
+    def __init__(self, parent):
+        super(Types, self).__init__(parent.api, 'available')
+
+    def search(self, pattern=''):
+        suffix = '/search'
+        if pattern:
+            suffix += '?' + pattern
+        return self.api.get(suffix)
+
+
+class Instances(ApiWrapper):
+    def __init__(self, parent):
+        super(Instances, self).__init__(parent.api, 'installed')
+
+    def instance(self, uuid):
+        return SingleInstance(self, uuid)
+
+    def search(self, pattern=''):
+        suffix = '/search'
+        if pattern:
+            suffix += '?' + pattern
+        return self.api.get(suffix)
+
+
+class SingleInstance(ApiWrapper):
+    def __init__(self, parent, uuid):
+        super(SingleInstance, self).__init__(parent.api, uuid)
+
+    def enable(self):
+        return self.api.post('/enable')
+
+    def disable(self):
+        return self.api.post('/disable')
+
+    def notifier(self, definition):
+        return self.api.post('/notifier', json=definition)

--- a/opsramp/tenant.py
+++ b/opsramp/tenant.py
@@ -26,6 +26,7 @@ import opsramp.rba
 import opsramp.monitoring
 import opsramp.msp
 import opsramp.devmgmt
+import opsramp.integrations
 
 
 class Tenant(ApiWrapper):
@@ -48,6 +49,9 @@ class Tenant(ApiWrapper):
 
     def policies(self):
         return opsramp.devmgmt.Policies(self)
+
+    def integrations(self):
+        return opsramp.integrations.Integrations(self)
 
     def get_alerts(self, searchpattern):
         return self.api.get('/alerts/search?queryString=%s' % searchpattern)


### PR DESCRIPTION
First steps into the world of "integrations" in OpsRamp.
I'm also including an examples update to exercise it.

There are two groups of integrations... "available" and "installed"
and the content of the two is quite different. The available ones are
individually quite small with only a couple of fields each whereas
the installed ones are large, because they contain urls and keys
and various other pieces of specific data.