### PR TITLE
Move encode_payload into base.py

### DIFF
--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -21,7 +21,20 @@
 # limitations under the License.
 
 from __future__ import print_function
+import base64
 import requests
+
+
+class Helpers(object):
+    # Returns a string containing a base64 encoded version of the
+    # content of the specified file. It was quite finicky to come
+    # up with a method that works on both Python 2 and 3 so please
+    # don't modify this, or test carefully if you do.
+    @staticmethod
+    def b64encode_payload(fname):
+        with open(fname, 'rb') as f:
+            content = base64.b64encode(f.read())
+        return content.decode()
 
 
 class PathTracker(object):

--- a/opsramp/rba.py
+++ b/opsramp/rba.py
@@ -20,7 +20,6 @@
 # limitations under the License.
 
 from __future__ import print_function
-import base64
 
 from opsramp.base import ApiWrapper
 
@@ -59,16 +58,6 @@ class Category(ApiWrapper):
 class Script(ApiWrapper):
     def __init__(self, parent, uuid):
         super(Script, self).__init__(parent.api, 'scripts/%s' % uuid)
-
-    # Returns a string containing a base64 encoded version of the
-    # content of the specified file. It was quite finicky to come
-    # up with a method that works on both Python 2 and 3 so please
-    # don't modify this, or test carefully if you do.
-    @staticmethod
-    def encode_payload(fname):
-        with open(fname, 'rb') as f:
-            content = base64.b64encode(f.read())
-        return content.decode()
 
     # A helper function for use with mkparameter & mkscript.
     @staticmethod

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 import unittest
 import base64
 
+from opsramp.base import Helpers
 from opsramp.rba import Script
 
 
@@ -26,7 +27,7 @@ class StaticsTest(unittest.TestCase):
         testfile = 'README.md'
         with open(testfile, 'rb') as f:
             expected = f.read()
-        actual64 = Script.encode_payload(testfile)
+        actual64 = Helpers.b64encode_payload(testfile)
         actual = base64.b64decode(actual64)
         assert actual == expected
 


### PR DESCRIPTION
OpsRamp uses this content encoding method in various places so move
it up from the Script class into base.py where it can be seen and
consumed by other classes.