### PR TITLE
Helper functions for creation of integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,22 @@ import opsramp.integrations
   - create\_instance(type\_name, definition) -> creates a new instance of an
   integration type on this Tenant. "definition" is a Python dict specifying
   details of the integration instance that is to be created.
-  Helper functions for creating these dicts will be added later.
+  - @staticmethod mkEmailAlert(display\_name, logo\_fname=None) ->
+  helper function that returns a Python dict suitable for creating or updating
+  an integration instance of type EMAILALERT.
+  - @staticmethod mkCustom(display\_name, logo\_fname=None, parent\_uuid=None) ->
+  helper function that returns a Python dict suitable for creating or updating
+  an integration instance of type CUSTOM.
+  - @staticmethod mkAzureARM(display\_name, arm\_subscription\_id,
+  arm\_tenant\_id, arm\_client\_id, arm\_secret\_key) ->
+  helper function that returns a Python dict suitable for creating or updating
+  an integration instance of type AZUREARM. Note that ARM and ASM integrations
+  are different and each has its own helper function.
+  - @staticmethod mkAzureASM(display\_name, arm\_subscription\_id,
+  arm\_mgmt\_cert, arm\_keystore\_pass) ->
+  helper function that returns a Python dict suitable for creating or updating
+  an integration instance of type AZUREASM. Note that ARM and ASM integrations
+  are different and each has its own helper function.
   - _available() -> A synonym for "types()" that I included because that's
   the name of the API endpoint in OpsRamp that returns this set of data.
   It took a while to figure out what the returned data means though,
@@ -282,6 +297,9 @@ import opsramp.integrations
   "definition" is a Python dict specifying details of the new configuration.
   The syntax is defined in the OpsRamp docs. Helper functions for creating
   these dicts will be added later.
+  - update(definition) -> "definition" is a Python dict specifying the changes
+  to be made to this instance. The contents are described in the OpsRamp docs
+  and helper functions to construct them exist in the Integrations class.
 
 ## The API objects and direct REST calls
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import base64
+import unittest
+
+from opsramp.integrations import Integrations
+
+
+class StaticsTest(unittest.TestCase):
+    def base_display_name(self, fn):
+        testname = 'Unit test 1'
+        actual = fn(
+            display_name=testname
+        )
+        expected = {
+            'displayName': testname
+        }
+        assert actual == expected
+
+    def base_logo(self, fn):
+        testname = 'Unit test 2'
+        testfile = 'README.md'
+        actual = fn(
+            display_name=testname,
+            logo_fname=testfile
+        )
+        encoded = actual['logo']['file']
+        cleartext = base64.b64decode(encoded)
+        with open(testfile, 'rb') as f:
+            content = f.read()
+        assert content == cleartext
+
+        expected = {
+            'displayName': testname,
+            'logo': {
+                'name': testfile,
+                'file': encoded
+            }
+        }
+        assert actual == expected
+
+    def test_base(self):
+        self.base_display_name(Integrations.mkBase)
+        self.base_logo(Integrations.mkBase)
+
+    def test_emailalert(self):
+        self.base_display_name(Integrations.mkEmailAlert)
+        self.base_logo(Integrations.mkEmailAlert)
+
+    def test_custom(self):
+        self.base_display_name(Integrations.mkCustom)
+        self.base_logo(Integrations.mkCustom)
+        testname = 'Custom integration unit test'
+        fakeuuid = 'deadbeef'
+        actual = Integrations.mkCustom(
+            display_name=testname,
+            parent_uuid=fakeuuid
+        )
+        expected = {
+            'displayName': testname,
+            'parentIntg': {
+                'id': fakeuuid
+            }
+        }
+        assert actual == expected
+
+    def test_ARM(self):
+        testname = 'Azure ARM integration unit test'
+        subscription_id = '123456789'
+        tenant_id = 'Some random Azure tenant'
+        client_id = 'Azure client shtuff'
+        secret_key = 'Open Sesame I Say!'
+        actual = Integrations.mkAzureARM(
+            display_name=testname,
+            arm_subscription_id=subscription_id,
+            arm_tenant_id=tenant_id,
+            arm_client_id=client_id,
+            arm_secret_key=secret_key
+        )
+        expected = {
+            'displayName': testname,
+            'credential': {
+                'credentialType': 'AZURE',
+                'AzureType': 'ARM',
+                'SubscriptionId': subscription_id,
+                'TenantId': tenant_id,
+                'ClientID': client_id,
+                'SecretKey': secret_key
+            }
+        }
+        assert actual == expected
+
+    def test_ASM(self):
+        testname = 'Azure ASM integration unit test'
+        subscription_id = 'ABCDEFGHIJKLMNOP'
+        mgmt_cert = 'Azure management cert'
+        keystore_pass = 'Abrakedabra'
+        actual = Integrations.mkAzureASM(
+            display_name=testname,
+            arm_subscription_id=subscription_id,
+            arm_mgmt_cert=mgmt_cert,
+            arm_keystore_pass=keystore_pass
+        )
+        expected = {
+            'displayName': testname,
+            'credential': {
+                'credentialType': 'AZURE',
+                'AzureType': 'ASM',
+                'SubscriptionId': subscription_id,
+                'ManagementCertificate': mgmt_cert,
+                'KeystorePassword': keystore_pass
+            }
+        }
+        assert actual == expected


### PR DESCRIPTION
The structs that OpsRamp wants for each type of integration are
quite different from each other so provide a set of helper functions
to aid in contructing them.

Also add unit tests for these helpers.