### PR TITLE
Add "samples" subdir with standalone example scripts

### DIFF
--- a/samples/__init__.py
+++ b/samples/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/samples/clients.py
+++ b/samples/clients.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+#
+# Exercise the opsramp module as an illustration of how to use it.
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import os
+import json
+
+import opsramp.binding
+
+
+def connect():
+    url = os.environ['OPSRAMP_URL']
+    key = os.environ['OPSRAMP_KEY']
+    secret = os.environ['OPSRAMP_SECRET']
+    return opsramp.binding.connect(url, key, secret)
+
+
+def main():
+    partner_id = os.environ['OPSRAMP_TENANT_ID']
+
+    ormp = connect()
+    partner = ormp.tenant(partner_id)
+    if partner.is_client():
+        print(partner_id, 'is not a partner-level tenant')
+        exit(2)
+
+    clients = partner.clients()
+    clist = clients.get()
+    print('[')
+    for cdata in clist:
+        print('  ', json.dumps(cdata))
+    print(']')
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/integrations.py
+++ b/samples/integrations.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+#
+# Exercise the opsramp module as an illustration of how to use it.
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import os
+
+import opsramp.binding
+
+
+def connect():
+    url = os.environ['OPSRAMP_URL']
+    key = os.environ['OPSRAMP_KEY']
+    secret = os.environ['OPSRAMP_SECRET']
+    return opsramp.binding.connect(url, key, secret)
+
+
+def main():
+    tenant_id = os.environ['OPSRAMP_TENANT_ID']
+
+    ormp = connect()
+    tenant = ormp.tenant(tenant_id)
+    integs = tenant.integrations()
+
+    group = integs.instances()
+    found = group.search()
+    for idata in found['results']:
+        in_auth, out_auth = group.auth_type(idata)
+        print(
+            idata['id'],
+            in_auth, out_auth,
+            idata['integration']['id'],
+            '\"%s\"' % idata.get('displayName', '<unnamed>')
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/timezones.py
+++ b/samples/timezones.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#
+# Exercise the opsramp module as an illustration of how to use it.
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import os
+import json
+
+import opsramp.binding
+
+
+def connect():
+    url = os.environ['OPSRAMP_URL']
+    key = os.environ['OPSRAMP_KEY']
+    secret = os.environ['OPSRAMP_SECRET']
+    return opsramp.binding.connect(url, key, secret)
+
+
+def main():
+    ormp = connect()
+    global_cfg = ormp.config()
+    tzs = global_cfg.get_timezones()
+    print('[')
+    for t in tzs:
+        print('  ', json.dumps(t))
+    print(']')
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The main examples.py has got large so while it's still good for a smoke
test it's not so good for conveying how the library is supposed to be
used. Add some new single-purpose samples to show that better.

I have written these to output JSON because that might make them useful
in the field. At the same time I know I'm taking a chance on people not
understanding that this is only one possible use of the return values.