### PR TITLE
MGM235 add sample script to install Email Alerts integration

### DIFF
--- a/samples/email_alerts_integration_create.py
+++ b/samples/email_alerts_integration_create.py
@@ -41,7 +41,7 @@ def main():
     jdata = {
         'displayName': 'Test Email Alerts integration',
         'emailProps': [{
-	    'name': 'logz.io eamil alert',
+	    'name': 'logz.io email alert',
             'identifier': '^\\[Alert\\]',
             'identifierSource': 'EMAIL_SUBJECT',
             'properties': [{

--- a/samples/email_alerts_integration_create.py
+++ b/samples/email_alerts_integration_create.py
@@ -18,7 +18,6 @@
 
 from __future__ import print_function
 import os
-import sys
 
 import opsramp.binding
 
@@ -41,11 +40,11 @@ def main():
     jdata = {
         'displayName': 'Test Email Alerts integration',
         'emailProps': [{
-	    'name': 'logz.io email alert',
+            'name': 'logz.io email alert',
             'identifier': '^\\[Alert\\]',
             'identifierSource': 'EMAIL_SUBJECT',
             'properties': [{
-		'name': 'Alert State',
+                'name': 'Alert State',
                 'defaultValue': 'OK',
                 'condition': {
                     'contentSource': 'EMAIL_SUBJECT',
@@ -58,32 +57,32 @@ def main():
                         'attrValue': 'Critical',
                         'thirdPartyAttrValue': 'Severe'
                     },
-                    {
+                        {
                         'attrValue': 'Warning',
                         'thirdPartyAttrValue': 'High'
                     },
-                    {
+                        {
                         'attrValue': 'Observed',
                         'thirdPartyAttrValue': 'Medium'
                     },
-                    {
+                        {
                         'attrValue': 'Info',
                         'thirdPartyAttrValue': 'Low'
                     },
-                    {
+                        {
                         'attrValue': 'Ok',
                         'thirdPartyAttrValue': 'Info'
                     }]
                 }
             },
-            {
+                {
                 'name': 'Service Name',
                 'defaultValue': 'whatever',
                 'condition': {
                     'contentSource': 'DEFAULT_VALUE'
                 }
             },
-            {
+                {
                 'name': 'Device Host Name',
                 'defaultValue': 'whatever',
                 'condition': {

--- a/samples/email_alerts_integration_create.py
+++ b/samples/email_alerts_integration_create.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+#
+# Exercise the opsramp module as an illustration of how to use it.
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import os
+import sys
+
+import opsramp.binding
+
+
+def connect():
+    url = os.environ['OPSRAMP_URL']
+    key = os.environ['OPSRAMP_KEY']
+    secret = os.environ['OPSRAMP_SECRET']
+    return opsramp.binding.connect(url, key, secret)
+
+
+def main():
+    tenant_id = os.environ['OPSRAMP_TENANT_ID']
+
+    ormp = connect()
+    tenant = ormp.tenant(tenant_id)
+    group = tenant.integrations().instances()
+
+    # Create new Email Alerts Integration...
+    jdata = {
+        'displayName': 'Test Email Alerts integration',
+        'emailProps': [{
+	    'name': 'logz.io eamil alert',
+            'identifier': '^\\[Alert\\]',
+            'identifierSource': 'EMAIL_SUBJECT',
+            'properties': [{
+		'name': 'Alert State',
+                'defaultValue': 'OK',
+                'condition': {
+                    'contentSource': 'EMAIL_SUBJECT',
+                    'operator': 'BETWEEN',
+                    'startValue': '\\(',
+                    'endValue': ' severity\\)'
+                },
+                'propertyMappings': {
+                    'attrValues': [{
+                        'attrValue': 'Critical',
+                        'thirdPartyAttrValue': 'Severe'
+                    },
+                    {
+                        'attrValue': 'Warning',
+                        'thirdPartyAttrValue': 'High'
+                    },
+                    {
+                        'attrValue': 'Observed',
+                        'thirdPartyAttrValue': 'Medium'
+                    },
+                    {
+                        'attrValue': 'Info',
+                        'thirdPartyAttrValue': 'Low'
+                    },
+                    {
+                        'attrValue': 'Ok',
+                        'thirdPartyAttrValue': 'Info'
+                    }]
+                }
+            },
+            {
+                'name': 'Service Name',
+                'defaultValue': 'whatever',
+                'condition': {
+                    'contentSource': 'DEFAULT_VALUE'
+                }
+            },
+            {
+                'name': 'Device Host Name',
+                'defaultValue': 'whatever',
+                'condition': {
+                    'contentSource': 'DEFAULT_VALUE'
+                }
+            }]
+        }]
+    }
+
+    resp = group.create('Email Alerts', jdata)
+    print(resp)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A sample script, email_alerts_integration_create.py, added to the samples/ folder, to install an Email Alerts integration required for Logz.io integration with GLOC. 

The script has been tested.

$ python3 -m samples.email_alerts_integration_create
{'integration': {'id': 'Email Alerts', 'name': 'Email Alerts'}, 'id': 'INTG-f2bbff56-d11d-484c-b724-0a91cf516e24', 'emailProps': [{'properties': [{'condition': {'startValue': '\\(', 'operator': 'BETWEEN', 'contentSource': 'EMAIL_SUBJECT', 'endValue': ' severity\\)'}, 'name': 'Alert State', 'defaultValue': 'OK'}, {'condition': {'contentSource': 'DEFAULT_VALUE'}, 'name': 'Service Name', 'defaultValue': 'whatever'}, {'condition': {'contentSource': 'DEFAULT_VALUE'}, 'name': 'Device Host Name', 'defaultValue': 'whatever'}], 'identifier': '^\\[Alert\\]', 'identifierSource': 'EMAIL_SUBJECT', 'name': 'logz.io eamil alert'}], 'displayName': 'Test Email Alerts integration'}
