### PR TITLE
Samples around client objects

### DIFF
--- a/samples/client_create_json.py
+++ b/samples/client_create_json.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+#
+# Exercise the opsramp module as an illustration of how to use it.
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import os
+import sys
+import json
+
+import opsramp.binding
+
+# Example input JSON file with the bare minimum mandatory fields:
+# {
+#   "name": "Todd Unctuous",
+#   "address": "Craggy Island",
+#   "country": "Ireland",
+#   "timeZone": "Europe/London"
+# }
+
+
+def connect():
+    url = os.environ['OPSRAMP_URL']
+    key = os.environ['OPSRAMP_KEY']
+    secret = os.environ['OPSRAMP_SECRET']
+    return opsramp.binding.connect(url, key, secret)
+
+
+def main():
+    partner_id = os.environ['OPSRAMP_TENANT_ID']
+
+    jdata = json.load(sys.stdin)
+    print(jdata)
+
+    ormp = connect()
+    partner = ormp.tenant(partner_id)
+    if partner.is_client():
+        print(partner_id, 'is not a partner-level tenant')
+        exit(2)
+
+    group = partner.clients()
+    resp = group.create(jdata)
+    print(resp)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/client_get.py
+++ b/samples/client_get.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+#
+# Exercise the opsramp module as an illustration of how to use it.
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import os
+import sys
+import json
+
+import opsramp.binding
+
+
+def connect():
+    url = os.environ['OPSRAMP_URL']
+    key = os.environ['OPSRAMP_KEY']
+    secret = os.environ['OPSRAMP_SECRET']
+    return opsramp.binding.connect(url, key, secret)
+
+
+def main():
+    partner_id = os.environ['OPSRAMP_TENANT_ID']
+
+    assert len(sys.argv) == 2
+    uniqueId = sys.argv[1]
+
+    ormp = connect()
+    partner = ormp.tenant(partner_id)
+    if partner.is_client():
+        print(partner_id, 'is not a partner-level tenant')
+        exit(2)
+
+    group = partner.clients()
+    resp = group.get(uniqueId)
+    print(json.dumps(resp, sort_keys=True, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/country_list.py
+++ b/samples/country_list.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#
+# Exercise the opsramp module as an illustration of how to use it.
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import os
+import json
+
+import opsramp.binding
+
+
+def connect():
+    url = os.environ['OPSRAMP_URL']
+    key = os.environ['OPSRAMP_KEY']
+    secret = os.environ['OPSRAMP_SECRET']
+    return opsramp.binding.connect(url, key, secret)
+
+
+def main():
+    ormp = connect()
+    global_cfg = ormp.config()
+    clist = global_cfg.get_countries()
+    print('[')
+    for c in clist:
+        print('  ', json.dumps(c))
+    print(']')
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
These are useful in their own right to view the raw contents of
the OpsRamp database.