### PR TITLE
requests_mock for unit test coverage on base.py

### DIFF
--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -103,20 +103,23 @@ class ApiObject(object):
         return new1
 
     def cd(self, path):
-        return self.tracker.cd(path)
+        self.tracker.cd(path)
+        return self.compute_url()
 
     def pushd(self, path):
-        return self.tracker.pushd(path)
+        self.tracker.pushd(path)
+        return self.compute_url()
 
     def popd(self):
-        return self.tracker.popd()
+        self.tracker.popd()
+        return self.compute_url()
 
     def chroot(self, suffix=''):
         suffix = self.tracker.fullpath(suffix)
         if suffix:
             self.baseurl += suffix
             self.tracker.reset()
-        return ''
+        return self.compute_url()
 
     def compute_url(self, suffix=''):
         retval = self.baseurl

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -16,3 +16,4 @@ flake8
 coverage
 pytest
 mock
+requests_mock

--- a/tests/test_api_class.py
+++ b/tests/test_api_class.py
@@ -57,9 +57,8 @@ class ApiOjectTest(unittest.TestCase):
         expected = self.ao.compute_url() + '/' + suffix
         assert self.ao.compute_url(suffix) == expected
 
-    # This does not need to test lots of use cases because "ao"
-    # is an instance of the ApiObject class which has its own
-    # unit tests that exercise all the variants it supports.
+    # We're not testing an exhaustive set of suffix patterns here because
+    # that is already being done by the PathTracker unit tests.
     def test_cd(self):
         suffix = 'unit/test/cd'
         expected = self.ao.compute_url() + '/' + suffix
@@ -67,9 +66,8 @@ class ApiOjectTest(unittest.TestCase):
         assert actual == expected
         assert self.ao.compute_url() == expected
 
-    # This does not need to test lots of use cases because "ao"
-    # is an instance of the ApiObject class which has its own
-    # unit tests that exercise all the variants it supports.
+    # We're not testing an exhaustive set of suffix patterns here because
+    # that is already being done by the PathTracker unit tests.
     def test_pushpopd(self):
         suffix = 'unit/test/pushd'
         base = self.ao.compute_url()
@@ -156,6 +154,8 @@ class ApiOjectTest(unittest.TestCase):
             actual = self.ao.delete()
             assert actual == expected
 
+    # We're not testing an exhaustive set of suffix patterns here because
+    # that is already being done by the ApiObject unit tests.
     def test_wrapped_get(self):
         with requests_mock.Mocker() as m:
             url = self.awrapper.api.compute_url()

--- a/tests/test_api_class.py
+++ b/tests/test_api_class.py
@@ -18,6 +18,7 @@ from __future__ import print_function
 import unittest
 import json
 from requests import codes as http_status
+import requests_mock
 
 import opsramp.binding
 
@@ -48,6 +49,37 @@ class ApiOjectTest(unittest.TestCase):
             self.fake_auth.copy()
         )
         assert 'ApiObject' in str(self.ao)
+        self.awrapper = opsramp.binding.ApiWrapper(self.ao, 'whatevs')
+        assert 'ApiWrapper' in str(self.awrapper)
+
+    def test_compute_url(self):
+        suffix = 'unit/test/value'
+        expected = self.ao.compute_url() + '/' + suffix
+        assert self.ao.compute_url(suffix) == expected
+
+    # This does not need to test lots of use cases because "ao"
+    # is an instance of the ApiObject class which has its own
+    # unit tests that exercise all the variants it supports.
+    def test_cd(self):
+        suffix = 'unit/test/cd'
+        expected = self.ao.compute_url() + '/' + suffix
+        actual = self.ao.cd(suffix)
+        assert actual == expected
+        assert self.ao.compute_url() == expected
+
+    # This does not need to test lots of use cases because "ao"
+    # is an instance of the ApiObject class which has its own
+    # unit tests that exercise all the variants it supports.
+    def test_pushpopd(self):
+        suffix = 'unit/test/pushd'
+        base = self.ao.compute_url()
+        expected = base + '/' + suffix
+        actual = self.ao.pushd(suffix)
+        assert actual == expected
+        assert self.ao.compute_url() == expected
+        actual = self.ao.popd()
+        assert actual == base
+        assert self.ao.compute_url() == base
 
     def test_headers(self):
         expected = self.fake_auth.copy()
@@ -91,3 +123,43 @@ class ApiOjectTest(unittest.TestCase):
         fake_resp.status_code = http_status.BAD_REQUEST
         with self.assertRaises(RuntimeError):
             self.ao.process_result(self.fake_url, fake_resp)
+
+    def test_get(self):
+        with requests_mock.Mocker() as m:
+            url = self.ao.compute_url()
+            expected = 'unit test get result'
+            m.get(url, text=expected)
+            actual = self.ao.get()
+            assert actual == expected
+
+    def test_put(self):
+        with requests_mock.Mocker() as m:
+            url = self.ao.compute_url()
+            expected = 'unit test put result'
+            m.put(url, text=expected)
+            actual = self.ao.put()
+            assert actual == expected
+
+    def test_post(self):
+        with requests_mock.Mocker() as m:
+            url = self.ao.compute_url()
+            expected = 'unit test post result'
+            m.post(url, text=expected)
+            actual = self.ao.post()
+            assert actual == expected
+
+    def test_delete(self):
+        with requests_mock.Mocker() as m:
+            url = self.ao.compute_url()
+            expected = 'unit test delete result'
+            m.delete(url, text=expected)
+            actual = self.ao.delete()
+            assert actual == expected
+
+    def test_wrapped_get(self):
+        with requests_mock.Mocker() as m:
+            url = self.awrapper.api.compute_url()
+            expected = 'unit test wrapped get result'
+            m.get(url, text=expected)
+            actual = self.awrapper.get()
+            assert actual == expected


### PR DESCRIPTION
This file contains the fundamental base classes of this module so
it's important to have good unit test coverage on them.

These are the first unit tests that result in actual attempts to
call the OpsRamp API, so I'm using the requests_mock module to stub
those out and control the return values.