### PR TITLE
Add integration with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[tox]
-envlist = py27,py3
-
-[testenv]
-deps = -rrequirements.txt
-       -rtest-requirements.txt
-
-commands =
-    ./runtests.sh
+language: python
+install:
+  - pip install -r requirements.txt -r test-requirements.txt
+python:
+  - "2.7"
+  - "3.6"
+script: ./runtests.sh

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,3 +1,11 @@
+#!/bin/bash
+#
+# runtests.sh
+# This script runs the actual test commands and assumes that the required
+# packages are already installed. Installation of the packages is done
+# outside of this script using pip install -r test-requirements.txt and
+# that command is already folded into our tox.ini
+#
 # (c) Copyright 2019 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,12 +20,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[tox]
-envlist = py27,py3
-
-[testenv]
-deps = -rrequirements.txt
-       -rtest-requirements.txt
-
-commands =
-    ./runtests.sh
+flake8 --ignore=none
+coverage run --concurrency=eventlet --include='opsramp/*' -m pytest -v
+coverage html
+coverage xml -o ./cover/coverage.xml
+coverage report


### PR DESCRIPTION
Facilitate running locally in tox or remotely in CI by moving the actual
test commands into a script that we invoke in both environments.