### PR TITLE
Add a second job that runs Python 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,40 +16,67 @@
 #
 version: 2
 jobs:
-  build:
+  unit_py36:
     docker:
-      - image: circleci/python:3.6.1
-
+      - image: circleci/python:3.6.8
     working_directory: ~/repo
-
     steps:
       - checkout
-
-      # Download and cache dependencies
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
+            - v1-dependencies-py3-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-
+            - v1-dependencies-py3-
       - run:
           name: install dependencies
           command: |
-            python3 -m venv venv
-            . venv/bin/activate
+            python3 -m venv venv3
+            . venv3/bin/activate
             pip install -r requirements.txt -r test-requirements.txt
-
       - save_cache:
           paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
-
+            - ./venv3
+          key: v1-dependencies-py3-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
       - run:
           name: run tests
           command: |
-            . venv/bin/activate
+            . venv3/bin/activate
             ./runtests.sh
-
       - store_artifacts:
           path: htmlcov
-          destination: htmlcov
+          destination: coverage
+  unit_py27:
+    docker:
+      - image: circleci/python:2.7.15
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-py2-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
+            - v1-dependencies-py2-
+      - run:
+          name: install dependencies
+          command: |
+            python -m virtualenv venv2
+            . venv2/bin/activate
+            pip install -r requirements.txt -r test-requirements.txt
+      - save_cache:
+          paths:
+            - ./venv2
+          key: v1-dependencies-py2-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
+      - run:
+          name: run tests
+          command: |
+            . venv2/bin/activate
+            ./runtests.sh
+      - store_artifacts:
+          path: htmlcov
+          destination: coverage
+
+workflows:
+  version: 2
+  workflow:
+    jobs:
+    - unit_py36
+    - unit_py27

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ limitations under the License.
 # python-opsramp
 A Python language binding for the OpsRamp API
 
+CI status: [![CircleCI](https://circleci.com/gh/HewlettPackard/python-opsramp.svg?style=svg)](https://circleci.com/gh/HewlettPackard/python-opsramp)
+
 ## About
 This directory tree contains a Python module that provides a convenient way to
 access the OpsRamp REST API programmatically. The OpsRamp API documentation is

--- a/runtests.sh
+++ b/runtests.sh
@@ -20,7 +20,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-flake8 --ignore=none --exclude=venv,.git,__pycache__,.tox,.eggs,*.egg
+flake8 --ignore=none --exclude=.git,__pycache__,.tox,.eggs,*.egg,venv,venv2,venv3
 coverage run --concurrency=eventlet --include='opsramp/*' -m pytest -v
 coverage html
 coverage xml -o ./cover/coverage.xml


### PR DESCRIPTION
We appear to need separate venvs per version so name them differently. Not sure this is actually needed, but it's no harm.
    
Also add a CI status marker to the README