### PR TITLE
Add the new RBAC roles function for OpsRamp 5.4.0

### DIFF
--- a/opsramp/examples.py
+++ b/opsramp/examples.py
@@ -48,6 +48,13 @@ def main():
     # Focus on a specific tenant.
     tenant = ormp.tenant(TENANT_ID)
 
+    print('List the RBAC roles on tenant', TENANT_ID)
+    group = tenant.roles()
+    found = group.search()
+    print(found['totalResults'], 'RBAC roles')
+    for i in found['results']:
+        print(i)
+
     print('List the integrations on tenant', TENANT_ID)
     integs = tenant.integrations()
     group = integs.itypes()

--- a/opsramp/roles.py
+++ b/opsramp/roles.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+#
+# A minimal Python language binding for the OpsRamp REST API.
+#
+# roles.py
+# Classes dealing directly with OpsRamp RBAC Roles.
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+from opsramp.base import ApiWrapper
+
+
+class Roles(ApiWrapper):
+    def __init__(self, parent):
+        super(Roles, self).__init__(parent.api, 'roles')
+
+    def search(self, pattern=''):
+        return self.api.get('/search?%s' % pattern)
+
+    def create(self, definition):
+        return self.api.post('', json=definition)
+
+    def update(self, uuid, definition):
+        return self.api.post('%s' % uuid, json=definition)
+
+    def delete(self, uuid):
+        return self.api.delete('%s' % uuid)

--- a/opsramp/tenant.py
+++ b/opsramp/tenant.py
@@ -27,6 +27,7 @@ import opsramp.monitoring
 import opsramp.msp
 import opsramp.devmgmt
 import opsramp.integrations
+import opsramp.roles
 
 
 class Tenant(ApiWrapper):
@@ -63,3 +64,6 @@ class Tenant(ApiWrapper):
 
     def credential_sets(self):
         return opsramp.devmgmt.CredentialSets(self)
+
+    def roles(self):
+        return opsramp.roles.Roles(self)

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import unittest
+import requests_mock
+
+import opsramp.binding
+
+
+class ApiTest(unittest.TestCase):
+    def setUp(self):
+        fake_url = 'http://api.example.com'
+        fake_token = 'unit-test-fake-token'
+        self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
+
+        self.fake_client_id = 'client_for_unit_test'
+        self.client = self.ormp.tenant(self.fake_client_id)
+        assert self.client.is_client()
+
+        self.roles = self.client.roles()
+        assert 'Roles' in str(self.roles)
+
+    def test_role_search(self):
+        group = self.roles
+        pattern = 'whatever'
+        url = group.api.compute_url('search?%s' % pattern)
+        expected = ['unit', 'test', 'list']
+        with requests_mock.Mocker() as m:
+            assert expected
+            m.get(url, json=expected)
+            actual = group.search(pattern)
+        assert actual == expected
+
+    def test_role_create(self):
+        group = self.roles
+        url = group.api.compute_url()
+        expected = {'id': 345678}
+        with requests_mock.Mocker() as m:
+            assert expected
+            m.post(url, json=expected)
+            actual = group.create(definition=expected)
+        assert actual == expected
+
+    def test_role_update(self):
+        group = self.roles
+        thisid = 123456
+        url = group.api.compute_url(thisid)
+        expected = {'id': thisid}
+        with requests_mock.Mocker() as m:
+            assert expected
+            m.post(url, json=expected)
+            actual = group.update(uuid=thisid, definition=expected)
+        assert actual == expected
+
+    def test_role_delete(self):
+        group = self.roles
+        thisid = 789012
+        url = group.api.compute_url(thisid)
+        expected = {'id': thisid}
+        with requests_mock.Mocker() as m:
+            assert expected
+            m.delete(url, json=expected)
+            actual = group.delete(uuid=thisid)
+        assert actual == expected

--- a/tests/test_tenant.py
+++ b/tests/test_tenant.py
@@ -44,9 +44,14 @@ class TenantTest(unittest.TestCase):
             assert actual == expected
 
     def test_clients(self):
+        # A partner object can have clients contained within it.
+        assert not self.msp.is_client()
+        assert self.msp.clients()
+        # A client object cannot have other clients nested inside it
+        # so it should raise an assertion if we try to access them.
+        assert self.client.is_client()
         with self.assertRaises(AssertionError):
             assert self.client.clients()
-        assert self.msp.clients()
 
     def test_methods_exist(self):
         assert self.client.rba()
@@ -55,3 +60,4 @@ class TenantTest(unittest.TestCase):
         assert self.client.discovery()
         assert self.client.integrations()
         assert self.client.credential_sets()
+        assert self.client.roles()


### PR DESCRIPTION
This upgrade introduced the use of RBAC roles in additional areas of
the API and made it more important to be able to access those.