### PR TITLE
Add sample to list roles

### DIFF
--- a/samples/roles_list.py
+++ b/samples/roles_list.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#
+# Exercise the opsramp module as an illustration of how to use it.
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import os
+import yaml
+
+import opsramp.binding
+
+
+def connect():
+    url = os.environ['OPSRAMP_URL']
+    key = os.environ['OPSRAMP_KEY']
+    secret = os.environ['OPSRAMP_SECRET']
+    return opsramp.binding.connect(url, key, secret)
+
+
+def main():
+    tenant_id = os.environ['OPSRAMP_TENANT_ID']
+
+    ormp = connect()
+    tenant = ormp.tenant(tenant_id)
+    group = tenant.roles()
+
+    found = group.search()
+    print(found['totalResults'], 'roles found in tenant', tenant_id)
+    print(yaml.dump(found['results'], default_flow_style=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Show how the roles api is used, at the most basic level. This is also
useful for listing the available roles on a given client/partner.