### PR TITLE
Have setup.py parse requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,16 +18,24 @@ import setuptools
 
 with open('README.md', 'r') as fh:
     long_description = fh.read()
+    long_description_content_type = 'text/markdown'
+
+with open('requirements.txt', 'r') as fh:
+    requirements = []
+    for line in fh.readlines():
+        line = line.strip()
+        if line[0] != '#':
+            requirements.append(line)
 
 setuptools.setup(
     name='python-opsramp',
     setup_requires=['setuptools_scm'],
     use_scm_version=True,
     author='HPE Greenlake Talos',
-    author_email='mercury.opsauto@hpe.com',
+    author_email='hcss_kalpana@hpe.com',
     description='Python language binding for the Opsramp API',
     long_description=long_description,
-    long_description_content_type='text/markdown',
+    long_description_content_type=long_description_content_type,
     keywords='opsramp',
     url='https://github.com/HewlettPackard/python-opsramp',
     license='Apache 2.0',
@@ -41,11 +49,10 @@ setuptools.setup(
         'Topic :: Software Development :: Libraries',
         'Operating System :: OS Independent',
     ],
-    install_requires=['requests'],
+    install_requires=requirements,
     entry_points={
         'console_scripts': [
             'ormpcli=opsramp.cli:main',
         ],
-    },
-
+    }
 )


### PR DESCRIPTION
Currently we have two independent lists of dependencies which is asking
for trouble. Resolve it by having setup.py parse requirements.txt so that
the latter becomes the canonical list of packages that we need.