### PR TITLE
YAML print of create email integration result

### DIFF
--- a/samples/email_alerts_integration_create.py
+++ b/samples/email_alerts_integration_create.py
@@ -18,6 +18,7 @@
 
 from __future__ import print_function
 import os
+import yaml
 
 import opsramp.binding
 
@@ -92,8 +93,12 @@ def main():
         }]
     }
 
+    print('create integration using this payload')
+    print(yaml.dump(jdata, default_flow_style=False))
+
     resp = group.create('Email Alerts', jdata)
-    print(resp)
+    print('result:')
+    print(yaml.dump(resp, default_flow_style=False))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It appears that OpsRamp has a bug whereby the email address for the
new email integration is not returned by the CREATE call. It is
deliberately omitted from GET so this bug means it can't be retrieved
programmatically at all.

This change to the relevant sample makes it print out the entire
return struct in YAML so that it's easy to see the omission and
will be easy to detect when it gets fixed in the future.