### PR TITLE
Simplify client search syntax

### DIFF
--- a/opsramp/msp.py
+++ b/opsramp/msp.py
@@ -32,10 +32,10 @@ class Clients(ApiWrapper):
         return self.api.get(suffix)
 
     def search(self, pattern=''):
-        return self.api.get('/search?%s' % pattern)
-
-    def search_for_prefix(self, prefix):
-        return self.api.get('/search?queryString=name:%s' % prefix)
+        path = '/search'
+        if pattern:
+            path += '?queryString=' + pattern
+        return self.api.get(path)
 
     def create(self, definition):
         assert 'name' in definition

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -98,11 +98,7 @@ class ApiTest(unittest.TestCase):
         url = group.api.compute_url('search')
         with requests_mock.Mocker() as m:
             m.get(url, json=expected)
-            # one search variant
-            actual = group.search('whatever')
-            assert actual == expected
-            # the other search variant
-            actual = group.search_for_prefix('pre-whatever')
+            actual = group.search('id=whatever')
             assert actual == expected
 
         url = group.api.compute_url('minimal')


### PR DESCRIPTION
There's no need for the client "search_for_prefix" function, it's just
a hardcoded version of the more general search syntax anyway. Refactor
to remove it and modify the search function to be more caller-friendly.