### PR TITLE
Move to Python 3.7 for CI and Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,9 @@
 #
 version: 2
 jobs:
-  unit_py36:
+  unit_py37:
     docker:
-      - image: circleci/python:3.6.8
+      - image: circleci/python:3.7.5
     working_directory: ~/repo
     steps:
       - checkout
@@ -78,5 +78,5 @@ workflows:
   version: 2
   workflow:
     jobs:
-    - unit_py36
+    - unit_py37
     - unit_py27

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.7.3-slim as build
+FROM python:3.7.5-slim as build
 RUN pip install --upgrade pip
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ADD . /build
 RUN pip install /build
 
-FROM python:3.7.3-slim as prod
+FROM python:3.7.5-slim as prod
 LABEL description="OpsRamp CLI"
 LABEL maintainer "HPE Greenlake Talos <mercury.opsauto@hpe.com>"
 COPY --from=build /usr/local /usr/local


### PR DESCRIPTION
I am deliberately leaving tox.ini as "py3" which means "the latest version
of Python3 that is available on this machine" so that we are not mandating
the version that the committer must install on their workstation. The CI
checks will run on the exact version anyway so we don't need to worry.