### PR TITLE
Make JSON detection more specific

### DIFF
--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -23,6 +23,12 @@
 from __future__ import print_function
 import base64
 import requests
+try:
+    # Python 3
+    from json.decoder import JSONDecodeError
+except ImportError:
+    # Python 2
+    JSONDecodeError = ValueError
 
 
 class Helpers(object):
@@ -148,7 +154,7 @@ class ApiObject(object):
             raise RuntimeError(msg)
         try:
             return resp.json()
-        except: # noqa
+        except JSONDecodeError:
             return resp.text
 
     def get(self, suffix='', headers={}):

--- a/tests/test_api_class.py
+++ b/tests/test_api_class.py
@@ -34,9 +34,11 @@ class FakeResp(object):
         self.request.method = 'FAKE'
 
     def json(self):
+        content = self.content
         if self.json_fail:
-            raise RuntimeError('deliberate json_fail')
-        return json.loads(self.content)
+            # deliberately cause a parsing exception
+            content = 'deliberately bad JSON for unit test purposes!!'
+        return json.loads(content)
 
 
 class ApiObjectTest(unittest.TestCase):


### PR DESCRIPTION
Only catch exceptions that are specifically related to JSON parsing errors
instead of everything. The type of exception that gets raised by the parser
is different on Python 2/3 so allow for that.