### PR TITLE
Add "delete" for scripts plus unit test

### DIFF
--- a/opsramp/rba.py
+++ b/opsramp/rba.py
@@ -59,6 +59,9 @@ class Category(ApiWrapper):
     def update(self, uuid, definition):
         return self.api.post('%s' % uuid, json=definition)
 
+    def delete(self, uuid):
+        return self.api.delete('%s' % uuid)
+
     # A helper function for use with mkParameter & mkScript.
     @staticmethod
     def mkAttachment(name, payload):

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -227,3 +227,14 @@ class ApiTest(unittest.TestCase):
                 uuid=scriptId, definition=expected
             )
             assert actual == expected
+
+    def test_delete_script(self):
+        this1 = self.rba.categories().category('unit-test-1')
+        assert this1
+        scriptId = 67890
+        expected = ''
+        with requests_mock.Mocker() as m:
+            url = this1.api.compute_url(scriptId)
+            m.delete(url, text=expected)
+            actual = this1.delete(uuid=scriptId)
+            assert actual == expected


### PR DESCRIPTION
There doesn't appear to be a delete operation for RBA Categories
but there is one for individual scripts so implement that.