### PR TITLE
Configuration for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+# Travis CI config file for the python-opsramp open source project.
+#
+# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+language: python
+install:
+  - pip install -r requirements.txt -r test-requirements.txt
+python:
+  - "2.7"
+  - "3.7"
+script: ./runtests.sh


### PR DESCRIPTION
Add a YAML configuration file that is required by Travis CI to tell
it how to run the integration tests.