### PR TITLE
collapse multi-page outputs into one page

### DIFF
--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -25,9 +25,11 @@ import base64
 import requests
 try:
     # Python 3
+    from urllib import parse as urlparse
     from json.decoder import JSONDecodeError
 except ImportError:
     # Python 2
+    import urlparse
     JSONDecodeError = ValueError
 
 
@@ -127,6 +129,65 @@ class ApiObject(object):
             self.tracker.reset()
         return self.compute_url()
 
+    @staticmethod
+    def collate_pages(get_request, data):
+        """Given a GET request whose results span across multiple pages, crawl
+        each page and collate the results.
+
+        :param first_page_data: "results" dict for first pagefull of dat
+        :type first_page_data: dict
+        :param request: Request used to get first page
+        :type request: requests.PreparedRequest
+        """
+        # First, sanity check that all is good. Only process GET requests:
+        if get_request.method.upper().strip() != "GET":
+            return data
+
+        collated_data = data["results"]
+
+        # Only attempt to pull subsequent pages if we can verify that there are
+        # subsequent pages "to be pulled"...
+        if "results" in data.keys():
+            while "nextPage" in data.keys() and data["nextPage"]:
+                # Get the next page full of data.
+                next_page = requests.get(
+                    get_request.url,
+                    params={'pageNo': int(data['pageNo']) + 1},
+                    headers=get_request.headers
+                )
+
+                if not next_page.ok:
+                    # Return an empty result.
+                    collated_data = []
+                    break
+
+                data = next_page.json()
+                collated_data = collated_data + data['results']
+                del next_page
+
+            # Dismantle the URL to see if data was requested in descending
+            # order...
+            query_params = dict(
+                urlparse.parse_qsl(urlparse.urlsplit(get_request.url).query)
+            )
+            descending_order = 'isDescendingOrder' in query_params.keys() and \
+                query_params['isDescendingOrder']
+
+            # Re-create the final data set as if it were a single page
+            # containing all records to ensure that existing stuff that expects
+            # this data structure doesn't fall over.
+            return {
+                'results': collated_data,
+                'totalResults': len(collated_data),
+                'pageNo': 1,
+                'pageSize': len(collated_data),
+                'nextPage': False,
+                'previousPageNo': 0,
+                'descendingOrder': descending_order
+            }
+        else:
+            return data
+
     def compute_url(self, suffix=''):
         retval = self.baseurl
         suffix = self.tracker.fullpath(suffix)
@@ -153,7 +214,16 @@ class ApiObject(object):
             )
             raise RuntimeError(msg)
         try:
-            return resp.json()
+            data = resp.json()
+            # Some GET requests return paginated output. If all the data fits
+            # in one page, return just the contents of the "results" list,
+            # otherwise, we need to do an assembly job to collate the entire
+            # list of results from all pages and return the full list.
+            if resp.request.method == "GET" and isinstance(data, dict) and \
+                    data.get("nextPage", None):
+                return ApiObject.collate_pages(resp.request, data=data)
+            else:
+                return data
         except JSONDecodeError:
             return resp.text
 

--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -143,11 +143,10 @@ class ApiObject(object):
         if get_request.method.upper().strip() != "GET":
             return data
 
-        collated_data = data["results"]
-
         # Only attempt to pull subsequent pages if we can verify that there are
         # subsequent pages "to be pulled"...
-        if "results" in data.keys():
+        if isinstance(data, dict) and "results" in data.keys():
+            collated_data = data["results"]
             while "nextPage" in data.keys() and data["nextPage"]:
                 # Get the next page full of data.
                 next_page = requests.get(

--- a/tests/test_api_class.py
+++ b/tests/test_api_class.py
@@ -18,27 +18,25 @@ from __future__ import print_function
 import unittest
 import json
 from requests import codes as http_status
+import requests
 import requests_mock
-from mock import MagicMock
-
 import opsramp.binding
 
 
 class FakeResp(object):
-    def __init__(self, content):
+    def __init__(self, content, request):
         self.status_code = http_status.OK
         self.content = content
-        self.text = str(self.content)
+        self.text = json.dumps(self.content)
         self.json_fail = False
-        self.request = MagicMock()
-        self.request.method = 'FAKE'
+        self.request = request
 
     def json(self):
         content = self.content
         if self.json_fail:
             # deliberately cause a parsing exception
             content = 'deliberately bad JSON for unit test purposes!!'
-        return json.loads(content)
+        return content
 
 
 class ApiObjectTest(unittest.TestCase):
@@ -112,26 +110,114 @@ class ApiObjectTest(unittest.TestCase):
         assert actual == expected
 
     def test_results(self):
-        expected = {'hello': 'world'}
-        fake_resp = FakeResp(json.dumps(expected))
-        actual = self.ao.process_result(self.fake_url, fake_resp)
-        assert type(actual) is dict
-        assert actual == expected
+        # Test successful response
 
-        fake_resp.json_fail = True
-        actual = self.ao.process_result(self.fake_url, fake_resp)
-        assert type(actual) is str
-        assert json.loads(actual) == expected
+        with requests_mock.mock() as m:
+            expected = {'hello': 'world'}
+            m.get(self.fake_url, json=expected, status_code=200)
 
-        fake_resp.status_code = http_status.BAD_REQUEST
-        fake_resp.request.method = 'UNIT-TEST-VALUE'
-        failed = False
-        try:
-            self.ao.process_result(self.fake_url, fake_resp)
-        except RuntimeError as e:
-            assert fake_resp.request.method in str(e)
-            failed = True
-        assert failed
+            faked_response = FakeResp(
+                content=expected,
+                request=requests.get(self.fake_url).request
+            )
+            actual = self.ao.process_result(self.fake_url, faked_response)
+            assert type(actual) is dict
+            assert actual == expected
+
+        # Test response where result is not valid JSON
+        with requests_mock.mock() as m:
+            expected = 'deliberately bad JSON for unit test purposes!!'
+            m.get(self.fake_url, text=expected)
+
+            faked_response = FakeResp(
+                content=['nothing'],
+                request=requests.get(self.fake_url).request
+            )
+
+            faked_response.json_fail = True
+
+            actual = self.ao.process_result(self.fake_url, faked_response)
+            assert type(actual) is str
+            assert actual == expected
+
+        # Test that exception is thrown if unexpected HTTP status code returned
+        with requests_mock.mock() as m:
+            m.get(
+                self.fake_url,
+                status_code=http_status.BAD_REQUEST,
+                text='Pretending to fail horribly'
+            )
+
+            faked_response = FakeResp(
+                content=['nothing'],
+                request=requests.get(self.fake_url).request
+            )
+            faked_response.status_code = http_status.BAD_REQUEST
+
+            failed = False
+            try:
+                actual = self.ao.process_result(self.fake_url, faked_response)
+            except RuntimeError as e:
+                print(e)
+                failed = True
+            assert failed
+
+    def test_paginated_results(self):
+        # Define three pages of test data that return the following result
+        # data:
+        # Page 1: 1-10
+        # Page 2: 11-20
+        # Page 3: 21-30
+        # If the pagination works, the result should be the range 1-30.
+        request_responses = []
+        for result_page in range(3):
+            result_data = list(
+                range((10 * result_page) + 1, (10 * result_page) + 11)
+            )
+
+            response_body = {
+                'results': result_data,
+                'totalResults': 30,
+                'pageNo': result_page + 1,
+                'pageSize': 10,
+                'nextPage': (result_page < 2),
+                'previousPageNo': result_page,
+                'descendingOrder': False
+            }
+
+            response = {
+                'status_code': 200,
+                'json': response_body,
+            }
+
+            request_responses.append(response)
+
+        # Build up the list of expected result data based on what we're feeding
+        # in to the mock.
+        expected = []
+        for response in request_responses:
+            expected = expected + response['json']['results']
+
+        with requests_mock.mock() as m:
+            # Feed the mock with the three responses it should return
+            m.get(self.fake_url, request_responses)
+
+            # Build the initial (faked) response based on the above
+            faked_response = FakeResp(
+                content=request_responses[0]['json'],
+                request=requests.get(self.fake_url).request
+            )
+            actual = self.ao.process_result(self.fake_url, faked_response)
+            assert type(actual) is dict
+
+            # So that no existing code is broken, the behaviour emulates the
+            # existing behaviour of the API except that it acts as if the data
+            # was in one big page.
+            assert actual['results'] == expected
+            assert actual['totalResults'] == len(expected)
+            assert actual['nextPage'] is False
+            assert actual['pageNo'] == 1
+            assert actual['previousPageNo'] == 0
 
     def test_get(self):
         with requests_mock.Mocker() as m:


### PR DESCRIPTION
If a request returns what appears to be one page in a set of multi-page outputs, this retrieves the remaining pages and assembles the results into a single, unified set.

In order not to break existing code, the returned data is structured to look like a single page of such output that happens to be big enough to contain all of the results.