### PR TITLE
Add delete support for integrations

### DIFF
--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -244,10 +244,10 @@ class ApiObject(object):
         resp = requests.put(url, headers=hdr, data=data, json=json)
         return self.process_result(url, resp)
 
-    def delete(self, suffix='', headers={}):
+    def delete(self, suffix='', headers={}, data=None, json=None):
         url = self.compute_url(suffix)
         hdr = self.prep_headers(headers)
-        resp = requests.delete(url, headers=hdr)
+        resp = requests.delete(url, headers=hdr, data=data, json=json)
         return self.process_result(url, resp)
 
 

--- a/opsramp/integrations.py
+++ b/opsramp/integrations.py
@@ -92,6 +92,12 @@ class Instances(ApiWrapper):
         resp = self.creator_api.post(type_name, json=definition)
         return resp
 
+    def delete(self, uuid, uninstall_reason="<Not specified>"):
+        json_payload = {
+            'uninstallReason': uninstall_reason
+        }
+        return self.api.delete(suffix=uuid, json=json_payload)
+
     def update(self, uuid, definition):
         return self.api.post('%s' % uuid, json=definition)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -115,11 +115,28 @@ class InstancesTest(unittest.TestCase):
         group = self.integs.instances()
         thisid = 999999
         url = group.api.compute_url('%s' % thisid)
-        expected = ''
+
+        expected_response = {'id': thisid}
+
+        # Test that a delete works as expected if reason not provided
+        expected_send = {"uninstallReason": "<Not specified>"}
         with requests_mock.Mocker() as m:
-            m.delete(url, text='')
-            actual = group.delete(uuid=thisid)
-        assert actual == expected
+            adapter = m.delete(url, json=expected_response)
+            actual_response = group.delete(uuid=thisid)
+            assert adapter.last_request.json() == expected_send
+            assert actual_response == expected_response
+
+        # Test that a delete works as expected if we provide a reason
+        delete_reason = 'Totally fake reason to delete something'
+        expected_send = {"uninstallReason": delete_reason}
+        with requests_mock.Mocker() as m:
+            adapter = m.delete(url, json=expected_response)
+            actual_response = group.delete(
+                uuid=thisid,
+                uninstall_reason=delete_reason
+            )
+            assert adapter.last_request.json() == expected_send
+            assert actual_response == expected_response
 
     def test_instance_notifier(self):
         group = self.integs.instances()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -111,6 +111,16 @@ class InstancesTest(unittest.TestCase):
             actual = group.disable(uuid=thisid)
         assert actual == expected
 
+    def test_instance_delete(self):
+        group = self.integs.instances()
+        thisid = 999999
+        url = group.api.compute_url('%s' % thisid)
+        expected = ''
+        with requests_mock.Mocker() as m:
+            m.delete(url, text='')
+            actual = group.delete(uuid=thisid)
+        assert actual == expected
+
     def test_instance_notifier(self):
         group = self.integs.instances()
         thisid = 901234


### PR DESCRIPTION
Deleting an integration requires the specification of a reason for the "uninstallation" as a JSON payload in the DELETE request. Added that here to make deletes possible.