### PR TITLE
Use the same requests session in clones

### DIFF
--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -93,14 +93,17 @@ class PathTracker(object):
 
 
 class ApiObject(object):
-    def __init__(self, url, auth, tracker=None):
-        self.session = requests.Session()
+    def __init__(self, url, auth, tracker=None, session=None):
         self.baseurl = url.rstrip('/')
         self.auth = auth
         if tracker:
             self.tracker = tracker
         else:
             self.tracker = PathTracker()
+        if session:
+            self.session = session
+        else:
+            self.session = requests.Session()
 
     def __str__(self):
         return '%s "%s" "%s"' % (
@@ -108,7 +111,12 @@ class ApiObject(object):
         )
 
     def clone(self):
-        new1 = ApiObject(self.baseurl, self.auth, self.tracker.clone())
+        new1 = ApiObject(
+            self.baseurl,
+            self.auth,
+            self.tracker.clone(),
+            self.session
+        )
         return new1
 
     def cd(self, path):

--- a/tests/test_api_class.py
+++ b/tests/test_api_class.py
@@ -56,6 +56,11 @@ class ApiObjectTest(unittest.TestCase):
         self.awrapper = opsramp.binding.ApiWrapper(self.ao, 'whatevs')
         assert 'ApiWrapper' in str(self.awrapper)
 
+    def test_shared_session(self):
+        '''All clones should share the requests session'''
+        ao2 = self.ao.clone()
+        assert ao2.session is self.ao.session
+
     def test_compute_url(self):
         suffix = 'unit/test/value'
         expected = self.ao.compute_url() + '/' + suffix


### PR DESCRIPTION
The ApiObject clone method is creating new session objects for each
clone. That's not what we want; we want all of the traffic from this
binding object to use one shared session, so cloning it all the time
defeats the purpose.