### PR TITLE
requests returns a different exception type on JSON errors

### DIFF
--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -6,7 +6,7 @@
 # Containing various base classes used in other parts of the library
 # but not intended for direct use by callers.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import requests
 try:
     # Python 3
     from urllib import parse as urlparse
-    from json.decoder import JSONDecodeError
+    from simplejson.errors import JSONDecodeError
 except ImportError:
     # Python 2
     import urlparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,3 +14,4 @@
 #
 eventlet
 requests
+simplejson


### PR DESCRIPTION
Field experience has shown that the Python requests package
returns a different exception type on JSON parsing errors
than originally thought.

Interestingly, this was discovered by running opsramp.examples
against a real OpsRamp server. The text response returned by
the "get agent script" API call exposed this error because the
attempt to parse it as JSON failed as expected, but the actual
type of exception raised was different from the one the unit
tests are using.