### PR TITLE
Permission Sets API objects

### DIFF
--- a/opsramp/roles.py
+++ b/opsramp/roles.py
@@ -3,9 +3,9 @@
 # A minimal Python language binding for the OpsRamp REST API.
 #
 # roles.py
-# Classes dealing directly with OpsRamp RBAC Roles.
+# Classes dealing directly with OpsRamp RBAC.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,3 +38,11 @@ class Roles(ApiWrapper):
 
     def delete(self, uuid):
         return self.api.delete('%s' % uuid)
+
+
+class PermissionSets(ApiWrapper):
+    def __init__(self, parent):
+        super(PermissionSets, self).__init__(parent.api, 'permissionSets')
+
+    def search(self, pattern=''):
+        return self.api.get('?%s' % pattern)

--- a/opsramp/tenant.py
+++ b/opsramp/tenant.py
@@ -73,6 +73,9 @@ class Tenant(ApiWrapper):
     def roles(self):
         return opsramp.roles.Roles(self)
 
+    def permission_sets(self):
+        return opsramp.roles.PermissionSets(self)
+
     def escalations(self):
         return opsramp.escalations.Escalations(self)
 

--- a/samples/permission_sets_list.py
+++ b/samples/permission_sets_list.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+#
+# Exercise the opsramp module as an illustration of how to use it.
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import os
+import yaml
+
+import opsramp.binding
+
+
+def connect():
+    url = os.environ['OPSRAMP_URL']
+    key = os.environ['OPSRAMP_KEY']
+    secret = os.environ['OPSRAMP_SECRET']
+    return opsramp.binding.connect(url, key, secret)
+
+
+def main():
+    tenant_id = os.environ['OPSRAMP_TENANT_ID']
+
+    ormp = connect()
+    tenant = ormp.tenant(tenant_id)
+    group = tenant.permission_sets()
+
+    # found = group.search()
+    found = group.get()
+    print(found['totalResults'], 'permission sets found in tenant', tenant_id)
+    print(yaml.dump(found['results'], default_flow_style=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/permission_sets_list.py
+++ b/samples/permission_sets_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -31,8 +31,32 @@ class ApiTest(unittest.TestCase):
         self.client = self.ormp.tenant(self.fake_client_id)
         assert self.client.is_client()
 
+        self.permission_sets = self.client.permission_sets()
+        assert 'PermissionSets' in str(self.permission_sets)
+
         self.roles = self.client.roles()
         assert 'Roles' in str(self.roles)
+
+    def test_permission_sets_get(self):
+        group = self.permission_sets
+        url = group.api.compute_url()
+        expected = ['unit', 'test', 'list']
+        with requests_mock.Mocker() as m:
+            m.get(url, json=expected)
+            actual = group.get()
+        assert actual == expected
+
+    def test_permission_sets_search(self):
+        group = self.permission_sets
+        for pattern, expected in (
+            ('', ['unit', 'test', 'results']),
+            ('pageNo=1&pageSize=100&is&sortName=id', ['more', 'nonsense'])
+        ):
+            url = group.api.compute_url('?%s' % pattern)
+            with requests_mock.Mocker() as m:
+                m.get(url, json=expected)
+                actual = group.search(pattern)
+            assert actual == expected
 
     def test_role_search(self):
         group = self.roles


### PR DESCRIPTION
Permissions sets underpin Roles in the OpsRamp RBAC system but can
only be created and updated in the UI today. However we can read the
list of existing sets and search it, so provide access to that.