### PR TITLE
Examples illustrating the resources API.

### DIFF
--- a/opsramp/examples.py
+++ b/opsramp/examples.py
@@ -107,6 +107,7 @@ def main():
         agent_script = tenant.get_agent_script()
         print('length', len(agent_script))
         print(agent_script.split('\n')[0])
+        print('')
     else:
         print('List the clients of tenant', TENANT_ID)
         group = tenant.clients()
@@ -127,6 +128,15 @@ def main():
         # uncomment these lines to actually create the client.
         # resp = group.create(cdef)
         # print(resp)
+
+    print('List the Resources on tenant', TENANT_ID)
+    if tenant.is_client():
+        group = tenant.resources()
+        found = group.minimal()
+        print(found['totalResults'], 'resources')
+        print(yaml.dump(found['results']))
+    else:
+        print('<clients only>')
 
     print('List the monitoring templates on tenant', TENANT_ID)
     monitoring = tenant.monitoring()

--- a/opsramp/resources.py
+++ b/opsramp/resources.py
@@ -23,12 +23,17 @@ from __future__ import print_function
 from opsramp.base import ApiWrapper
 
 
-def list2ormp(result_list):
-    '''Bizarrely, OpsRamp returns a simple list for some of
-    the Resources API calls. This function wraps it up into
-    a fake of the typical OpsRamp return struct so that callers
-    don't have to special case this.'''
-    count = len(result_list)
+def list2ormp(result_obj):
+    '''Bizarrely, OpsRamp sometimes returns a simple list for
+    Resources API calls instead of its usual results struct.'''
+    if isinstance(result_obj, dict):
+        assert 'results' in result_obj
+        assert 'totalResults' in result_obj
+        return result_obj
+    # Wrap it up in a fake of the typical OpsRamp results struct
+    # so that callers don't have to special case it.
+    assert isinstance(result_obj, list)
+    count = len(result_obj)
     retval = {
         'totalResults': count,
         'pageSize': count,
@@ -37,7 +42,7 @@ def list2ormp(result_list):
         'previousPageNo': 0,
         'nextPage': False,
         'descendingOrder': False,
-        'results': result_list
+        'results': result_obj
     }
     return retval
 

--- a/samples/resources_list.py
+++ b/samples/resources_list.py
@@ -36,19 +36,15 @@ def main():
     ormp = connect()
     tenant = ormp.tenant(tenant_id)
 
-    jdata = {
-        "hostName": "testdevice-api",
-        "resourceType": "server",
-        "managementProfile": "dummy-profile",
-        "resourceNetworkInterface": [{
-            "ipAddressType": "STATIC",
-            "ipAddress": "10.10.10.10"
-        }
-        ]
-    }
-    resources = tenant.resources()
-    resp = resources.create(jdata)
-    print(yaml.dump(resp, default_flow_style=False))
+    group = tenant.resources()
+    if tenant.is_client():
+        resp = group.minimal()
+    else:
+        # I would prefer minimal but it doesn't work on partner.
+        resp = group.search()
+
+    print(resp['totalResults'], 'resources')
+    print(yaml.dump(resp['results'], default_flow_style=False))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
These are hard to test at partner level, simply because our dev
instance of OpsRamp has *so* many resources in it. However I
persevered and it completed successfully. Approx 4.5 minutes
to retrieve the set of 15247 resources that exist on the dev instance
today.