### PR TITLE
Nitpicks from flake8-bugbear

### DIFF
--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -233,25 +233,25 @@ class ApiObject(object):
         except JSONDecodeError:
             return resp.text
 
-    def get(self, suffix='', headers={}):
+    def get(self, suffix='', headers=None):
         url = self.compute_url(suffix)
         hdr = self.prep_headers(headers)
         resp = self.session.get(url, headers=hdr)
         return self.process_result(url, resp)
 
-    def post(self, suffix='', headers={}, data=None, json=None):
+    def post(self, suffix='', headers=None, data=None, json=None):
         url = self.compute_url(suffix)
         hdr = self.prep_headers(headers)
         resp = self.session.post(url, headers=hdr, data=data, json=json)
         return self.process_result(url, resp)
 
-    def put(self, suffix='', headers={}, data=None, json=None):
+    def put(self, suffix='', headers=None, data=None, json=None):
         url = self.compute_url(suffix)
         hdr = self.prep_headers(headers)
         resp = self.session.put(url, headers=hdr, data=data, json=json)
         return self.process_result(url, resp)
 
-    def delete(self, suffix='', headers={}, data=None, json=None):
+    def delete(self, suffix='', headers=None, data=None, json=None):
         url = self.compute_url(suffix)
         hdr = self.prep_headers(headers)
         resp = self.session.delete(url, headers=hdr, data=data, json=json)
@@ -267,5 +267,5 @@ class ApiWrapper(object):
     def __str__(self):
         return '%s %s' % (str(type(self)), self.api)
 
-    def get(self, suffix='', headers={}):
+    def get(self, suffix='', headers=None):
         return self.api.get(suffix, headers)

--- a/opsramp/msp.py
+++ b/opsramp/msp.py
@@ -5,7 +5,7 @@
 # msp.py
 # Classes related to partner-level actions.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -59,10 +59,14 @@ class Clients(ApiWrapper):
     # Helper functions to create the complex structures that OpsRamp
     # uses to manipulate client definitions.
     @staticmethod
-    def mkHours(day_start=datetime.time(9, 0),
-                day_end=datetime.time(17, 0),
+    def mkHours(day_start=None,
+                day_end=None,
                 week_start=2, week_end=6,
                 sms_voice_notification=False):
+        if not day_start:
+            day_start = datetime.time(9, 0)
+        if not day_end:
+            day_end = datetime.time(17, 0)
         retval = {
             'businessStartHour': day_start.hour,
             'businessStartMin': day_start.minute,

--- a/opsramp/rba.py
+++ b/opsramp/rba.py
@@ -5,7 +5,7 @@
 # rba.py
 # Runbook Automation related classes
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ class Category(ApiWrapper):
     def mkScript(name, description, platforms, execution_type,
                  payload=None,
                  payload_file=None,
-                 parameters=[],
+                 parameters=None,
                  script_name=None,
                  install_timeout=0,
                  registry_path=None,

--- a/tests/test_pathtracker.py
+++ b/tests/test_pathtracker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,7 +66,7 @@ class TrackerTest(unittest.TestCase):
                 assert not pshort
                 self.trkr.popd()
             else:
-                assert False
+                raise AssertionError('unexpected action %s' % action)
             assert self.trkr.fullpath() == pfull
 
     def test_reset(self):


### PR DESCRIPTION
These are mostly around the use of empty dicts {} as defaults in function
definitions. Technically that syntax results in a static dict that is used
again every time a caller omits the argument, so in theory if the function
made changes to the dict those would persist to the next call. I don't
see any instances of us doing that, but I'm removing the possibility.