### PR TITLE
mgmt_profiles attach/detach use GET not POST

### DIFF
--- a/opsramp/mgmt_profiles.py
+++ b/opsramp/mgmt_profiles.py
@@ -44,10 +44,10 @@ class Profiles(ApiWrapper):
         return self.api.delete('%s' % uuid)
 
     def attach(self, uuid):
-        return self.api.post('%s/attach' % uuid)
+        return self.api.get('%s/attach' % uuid)
 
     def detach(self, uuid):
-        return self.api.post('%s/detach' % uuid)
+        return self.api.get('%s/detach' % uuid)
 
     def reconnect(self, uuid):
         return self.api.get('%s/reconnectTunnel' % uuid)

--- a/tests/test_mgmt_profiles.py
+++ b/tests/test_mgmt_profiles.py
@@ -79,7 +79,7 @@ class ApiTest(unittest.TestCase):
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
             assert expected
-            m.post(url, json=expected)
+            m.get(url, json=expected)
             actual = self.group.attach(uuid=thisid)
         assert actual == expected
 
@@ -89,7 +89,7 @@ class ApiTest(unittest.TestCase):
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
             assert expected
-            m.post(url, json=expected)
+            m.get(url, json=expected)
             actual = self.group.detach(uuid=thisid)
         assert actual == expected
 


### PR DESCRIPTION
Methods to attach/detach connected devices from Management Profiles don't work because the methods are using the POST method instead of GET. This fixes that.

Justification: https://docs.opsramp.com/management-profile-apis/#Attach_Gateway_to_Management_Profile