### PR TITLE
Add newer tenant properties to examples.py

### DIFF
--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -62,7 +62,7 @@ class Helpers(object):
     # https://www.peterbe.com/plog/best-practice-with-retries-with-requests
     @staticmethod
     def session_add_retry_handler(
-        retries=5, backoff_factor=0.3, status_forcelist=(429,), session=None
+        retries=7, backoff_factor=1, status_forcelist=(429,), session=None
     ):
         session = session or requests.Session()
         retry = Helpers.create_retry_handler(

--- a/opsramp/examples.py
+++ b/opsramp/examples.py
@@ -49,6 +49,20 @@ def main():
     # Focus on a specific tenant.
     tenant = ormp.tenant(TENANT_ID)
 
+    if tenant.is_client():
+        print('List the First Response Policies on tenant', TENANT_ID)
+        group = tenant.first_response()
+        found = group.search()
+        print(found['totalResults'], 'first response policies')
+        print(yaml.dump(found['results'], default_flow_style=False))
+
+    if tenant.is_client():
+        print('List the Service Maps on tenant', TENANT_ID)
+        group = tenant.service_maps()
+        found = group.get(minimal=True)
+        print(len(found), 'service maps')
+        print(yaml.dump(found, default_flow_style=False))
+
     print('List the RBAC permission sets on tenant', TENANT_ID)
     group = tenant.permission_sets()
     found = group.search()


### PR DESCRIPTION
Some of the most recently added properties are not being exercised by
examples.py so fix that. As a driveby, the timeout value for the 429
rate limiting code is too short so increase it. Running examples.py
nearly always causes rate limiting because it makes so many API calls
in a short period, so this is a good test of the retry code and in
fact it was getting retries exceeded which is why I increased the values.