### PR TITLE
Add PATCH support in the low-level class ApiObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,4 +517,9 @@ calls yourself.
   and should be avoided._
   - delete(suffix='', headers={}) -> performs a DELETE to the specified REST endpoint and returns the body of
   the server's reply. "headers" is an optional dict containing any additional HTTP headers that you want to send.
+  - patch(suffix='', headers={}, data=None, json=None) -> performs a PATCH to the specified REST endpoint and
+  returns the body of the server's reply. "headers" is an optional dict containing any additional HTTP headers
+  that you want to send, "data" is the text body, or "json" is a Python struct to be converted to a JSON
+  string and sent as a body. _Specifying both "data" and "json" in the same call results in undefined behavior
+  and should be avoided._
   - _we will add other http actions if/when a specific need for them arises_

--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -301,6 +301,12 @@ class ApiObject(object):
         resp = self.session.delete(url, headers=hdr, data=data, json=json)
         return self.process_result(url, resp)
 
+    def patch(self, suffix='', headers=None, data=None, json=None):
+        url = self.compute_url(suffix)
+        hdr = self.prep_headers(headers)
+        resp = self.session.patch(url, headers=hdr, data=data, json=json)
+        return self.process_result(url, resp)
+
 
 class ApiWrapper(object):
     def __init__(self, apiobject, suffix=''):

--- a/tests/test_api_class.py
+++ b/tests/test_api_class.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -297,6 +297,14 @@ class ApiObjectTest(unittest.TestCase):
             expected = 'unit test delete result'
             m.delete(url, text=expected)
             actual = self.ao.delete()
+            assert actual == expected
+
+    def test_patch(self):
+        with requests_mock.Mocker() as m:
+            url = self.ao.compute_url()
+            expected = 'unit test patch result'
+            m.patch(url, text=expected)
+            actual = self.ao.patch()
             assert actual == expected
 
     # We're not testing an exhaustive set of suffix patterns here because


### PR DESCRIPTION
We had a request to add PATCH to the set of low-level REST operations
that we support, so this adds it plus a unit test.