### PR TITLE
Move search() into the base class ORapi

### DIFF
--- a/opsramp/api.py
+++ b/opsramp/api.py
@@ -42,3 +42,10 @@ class ORapi(ApiWrapper):
 
     def get(self, suffix='', headers=None):
         return self.api.get(suffix, headers)
+
+    def search(self, pattern='', headers=None, suffix='search'):
+        if pattern:
+            if pattern[0] != '?':
+                pattern = '?' + pattern
+            suffix += pattern
+        return self.api.get(suffix, headers)

--- a/opsramp/devmgmt.py
+++ b/opsramp/devmgmt.py
@@ -28,10 +28,15 @@ class Policies(ORapi):
         super(Policies, self).__init__(parent.api, 'policies/management')
 
     def search(self, policy_name=''):
-        suffix = 'search'
-        if policy_name:
-            suffix += '?name=' + policy_name
-        return self.api.get(suffix)
+        '''For historical reasons this class's search function might be
+        called with just a name. We have to cope and convert it into a
+        proper query string.'''
+        if policy_name and '=' not in policy_name:
+            qstring = 'name=' + policy_name
+        else:
+            qstring = policy_name
+        # we have assembled a proper query string now so use regular search.
+        return super(Policies, self).search(pattern=qstring)
 
     def create(self, definition):
         return self.api.post('', json=definition)
@@ -52,10 +57,15 @@ class Discovery(ORapi):
         super(Discovery, self).__init__(parent.api, 'policies/discovery')
 
     def search(self, profile_name=''):
-        suffix = 'search'
-        if profile_name:
-            suffix += '?name=' + profile_name
-        return self.api.get(suffix)
+        '''For historical reasons this class's search function might be
+        called with just a name. We have to cope and convert it into a
+        proper query string.'''
+        if profile_name and '=' not in profile_name:
+            qstring = 'name=' + profile_name
+        else:
+            qstring = profile_name
+        # we have assembled a proper query string now so use regular search.
+        return super(Discovery, self).search(pattern=qstring)
 
     def create(self, definition):
         return self.api.post('', json=definition)

--- a/opsramp/escalations.py
+++ b/opsramp/escalations.py
@@ -27,12 +27,6 @@ class Escalations(ORapi):
     def __init__(self, parent):
         super(Escalations, self).__init__(parent.api, 'escalations')
 
-    def search(self, pattern=''):
-        suffix = 'search'
-        if pattern:
-            suffix += '?' + pattern
-        return self.api.get(suffix)
-
     def create(self, definition):
         return self.api.post('', json=definition)
 

--- a/opsramp/first_response.py
+++ b/opsramp/first_response.py
@@ -29,9 +29,10 @@ class First_Response(ORapi):
                                              'policies/firstResponse')
 
     def search(self, pattern=''):
-        if pattern:
-            pattern = '?' + pattern
-        return self.api.get(pattern)
+        return super(First_Response, self).search(
+            pattern=pattern,
+            suffix=''
+        )
 
     def policy_detail(self, uuid):
         return self.api.get('%s' % uuid)

--- a/opsramp/integrations.py
+++ b/opsramp/integrations.py
@@ -69,12 +69,6 @@ class Types(ORapi):
     def __init__(self, parent):
         super(Types, self).__init__(parent.api, 'available')
 
-    def search(self, pattern=''):
-        suffix = 'search'
-        if pattern:
-            suffix += '?' + pattern
-        return self.api.get(suffix)
-
 
 class Instances(ORapi):
     def __init__(self, parent):
@@ -83,12 +77,6 @@ class Instances(ORapi):
         # atypical place in the tree so need to compute it.
         self.creator_api = parent.api.clone()
         self.creator_api.chroot('install')
-
-    def search(self, pattern=''):
-        suffix = 'search'
-        if pattern:
-            suffix += '?' + pattern
-        return self.api.get(suffix)
 
     def get_kubernetes_configuration(self, uuid):
         return self.api.get('%s/configFile/kubernetes' % uuid)
@@ -120,6 +108,7 @@ class Instances(ORapi):
         return self.api.post('%s/disable' % uuid)
 
     def notifier(self, uuid, definition):
+        # Create or update installed integration base notifier
         return self.api.post('%s/notifier' % uuid, json=definition)
 
     # A helper function that extracts the authentication types from typical

--- a/opsramp/mgmt_profiles.py
+++ b/opsramp/mgmt_profiles.py
@@ -28,12 +28,6 @@ class Profiles(ORapi):
     def __init__(self, parent):
         super(Profiles, self).__init__(parent.api, 'managementProfiles')
 
-    def search(self, pattern=''):
-        suffix = 'search'
-        if pattern:
-            suffix += '?' + pattern
-        return self.api.get(suffix)
-
     def create(self, definition):
         return self.api.post('', json=definition)
 

--- a/opsramp/monitoring.py
+++ b/opsramp/monitoring.py
@@ -34,9 +34,3 @@ class Monitoring(ORapi):
 class Templates(ORapi):
     def __init__(self, parent):
         super(Templates, self).__init__(parent.api, 'templates')
-
-    def search(self, pattern=''):
-        suffix = 'search'
-        if pattern:
-            suffix += '?' + pattern
-        return self.api.get(suffix)

--- a/opsramp/msp.py
+++ b/opsramp/msp.py
@@ -32,10 +32,14 @@ class Clients(ORapi):
         return self.api.get(suffix)
 
     def search(self, query_string=''):
-        suffix = 'search'
-        if query_string:
-            suffix += '?queryString=' + query_string
-        return self.api.get(suffix)
+        # For historical reasons the caller is allowed to omit the
+        # queryString prefix, so add it if necessary.
+        key = 'queryString='
+        if query_string and key not in query_string:
+            query_string = key + query_string
+        return super(Clients, self).search(
+            pattern=query_string
+        )
 
     def create(self, definition):
         assert 'name' in definition

--- a/opsramp/resources.py
+++ b/opsramp/resources.py
@@ -65,18 +65,18 @@ class Resources(ORapi):
 
     def search(self, pattern=''):
         '''returns *verbose* details about resources on this tenant'''
-        suffix = 'search'
-        if pattern:
-            suffix += '?' + pattern
-        simple_list = self.api.get(suffix)
+        simple_list = super(Resources, self).search(
+            pattern=pattern,
+            suffix='search'
+        )
         return list2ormp(simple_list)
 
     def minimal(self, pattern=''):
         '''returns *minimal* details about resources on this tenant'''
-        url_suffix = 'minimal'
-        if pattern:
-            url_suffix += '?{0}'.format(pattern)
-        simple_list = self.api.get(url_suffix)
+        simple_list = super(Resources, self).search(
+            pattern=pattern,
+            suffix='minimal'
+        )
         return list2ormp(simple_list)
 
     def applications(self, uuid):

--- a/opsramp/roles.py
+++ b/opsramp/roles.py
@@ -27,12 +27,6 @@ class Roles(ORapi):
     def __init__(self, parent):
         super(Roles, self).__init__(parent.api, 'roles')
 
-    def search(self, pattern=''):
-        suffix = 'search'
-        if pattern:
-            suffix += '?' + pattern
-        return self.api.get(suffix)
-
     def create(self, definition):
         return self.api.post('', json=definition)
 
@@ -48,6 +42,7 @@ class PermissionSets(ORapi):
         super(PermissionSets, self).__init__(parent.api, 'permissionSets')
 
     def search(self, pattern=''):
-        if pattern:
-            pattern = '?' + pattern
-        return self.api.get(pattern)
+        return super(PermissionSets, self).search(
+            pattern=pattern,
+            suffix=''
+        )

--- a/opsramp/sites.py
+++ b/opsramp/sites.py
@@ -31,12 +31,6 @@ class Sites(ORapi):
     def get(self, suffix='/minimal'):
         return self.api.get(suffix)
 
-    def search(self, pattern=''):
-        suffix = 'search'
-        if pattern:
-            suffix += '?' + pattern
-        return self.api.get(suffix)
-
     def create(self, definition):
         return self.api.post('', json=definition)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -94,79 +94,82 @@ class ApiTest(unittest.TestCase):
         assert self.clients
 
     def test_search(self):
-        url = self.clients.api.compute_url('search')
-        expected = ['unit', 'test', 'list']
+        thisid = 444444
+        expected = {'id': thisid}
+        url = self.clients.api.compute_url('search?queryString=id:%s' % thisid)
         with requests_mock.Mocker() as m:
-            m.get(url, json=expected)
-            actual = self.clients.search('id=whatever')
+            m.get(url, json=expected, complete_qs=True)
+            actual = self.clients.search('id:%s' % thisid)
             assert actual == expected
 
     def test_minimal(self):
+        thisid = 555555
+        expected = {'id': thisid}
         url = self.clients.api.compute_url('minimal')
-        expected = ['unit', 'test', 'list']
         with requests_mock.Mocker() as m:
-            m.get(url, json=expected)
-            # default suffix
-            actual = self.clients.get()
-            assert actual == expected
-            # specific suffix
+            m.get(url, json=expected, complete_qs=True)
+            # specific suffix.
             actual = self.clients.get('minimal')
+            assert actual == expected
+            # default suffix should be the same.
+            actual = self.clients.get()
             assert actual == expected
 
     def test_create_update(self):
-        url = self.clients.api.compute_url()
-        expected = ['unit', 'test', 'list']
+        bad_definition = {'bogus': 'dude'}
         with requests_mock.Mocker() as m:
-            m.post(url, json=expected)
-            assert 'name' not in expected
             # the name field is missing so we should get an error.
+            assert 'name' not in bad_definition
             with self.assertRaises(AssertionError):
-                actual = self.clients.create(definition=expected)
+                actual = self.clients.create(definition=bad_definition)
+            assert m.call_count == 0
         # now let's try a valid one.
-        fake_definition = {
+        good_definition = {
             'name': 'elvis',
             'address': 'graceland',
             'timeZone': 'UTC',
             'country': 'US'
         }
+        thisid = 555555
+        expected = {'id': thisid}
+        url = self.clients.api.compute_url()
         with requests_mock.Mocker() as m:
-            m.post(url, json=fake_definition)
-            actual = self.clients.create(definition=fake_definition)
-            assert actual == fake_definition
-        # and try an update
-        thisid = 123456
+            m.post(url, json=expected, complete_qs=True)
+            actual = self.clients.create(definition=good_definition)
+            assert actual == expected
+        # now try update
         url = self.clients.api.compute_url(thisid)
         with requests_mock.Mocker() as m:
-            m.post(url, json=fake_definition)
+            m.post(url, json=expected, complete_qs=True)
             actual = self.clients.update(
                 uuid=thisid,
-                definition=fake_definition
+                definition=good_definition
             )
-            assert actual == fake_definition
+            assert actual == expected
 
     def test_suspend(self):
         thisid = 789012
+        expected = {'id': thisid}
         url = self.clients.api.compute_url('%s/suspend' % thisid)
-        expected = ['unit', 'test', 'list']
         with requests_mock.Mocker() as m:
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = self.clients.suspend(uuid=thisid)
             assert actual == expected
 
     def test_activate(self):
         thisid = 345678
+        expected = {'id': thisid}
         url = self.clients.api.compute_url('%s/activate' % thisid)
-        expected = ['unit', 'test', 'list']
         with requests_mock.Mocker() as m:
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = self.clients.activate(uuid=thisid)
             assert actual == expected
 
     def test_terminate(self):
         thisid = 901234
+        expected = {'id': thisid}
         url = self.clients.api.compute_url('%s/terminate' % thisid)
-        expected = ['unit', 'test', 'list']
         with requests_mock.Mocker() as m:
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = self.clients.terminate(uuid=thisid)
             assert actual == expected

--- a/tests/test_devmgmt.py
+++ b/tests/test_devmgmt.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,32 +34,47 @@ class DevmgmtText(unittest.TestCase):
     def test_policies(self):
         group = self.client.policies()
         assert group
-        expected = ['unit', 'test', 'list']
-        assert expected
         with requests_mock.Mocker() as m:
-            url = group.api.compute_url('search')
-            m.get(url, json=expected)
-            actual = group.search('whatever')
+            # The search function in this class supports two search
+            # syntaxes so test both.
+            display_name = 'whatever'
+            expected = {'id': 'abcdefg', 'name': display_name}
+            url = group.api.compute_url('search?name=%s' % display_name)
+            m.get(url, json=expected, complete_qs=True)
+            # The old simple search syntax.
+            actual = group.search(display_name)
+            assert actual == expected
+            # The newer query syntax.
+            actual = group.search('name=%s' % display_name)
             assert actual == expected
 
+        with requests_mock.Mocker() as m:
+            thisid = 111111
+            expected = {'id': thisid}
             url = group.api.compute_url()
             m.post(url, json=expected)
             actual = group.create(definition=expected)
             assert actual == expected
 
+        with requests_mock.Mocker() as m:
             thisid = 123456
+            expected = {'id': thisid}
             url = group.api.compute_url(thisid)
             m.put(url, json=expected)
             actual = group.update(uuid=thisid, definition=expected)
             assert actual == expected
 
+        with requests_mock.Mocker() as m:
             thisid = 789012
+            expected = {'id': thisid}
             url = group.api.compute_url('%s/action/run' % thisid)
             m.get(url, json=expected)
             actual = group.run(uuid=thisid)
             assert actual == expected
 
+        with requests_mock.Mocker() as m:
             thisid = 345678
+            expected = {'id': thisid}
             url = group.api.compute_url(thisid)
             m.delete(url, json=expected)
             actual = group.delete(uuid=thisid)
@@ -68,32 +83,47 @@ class DevmgmtText(unittest.TestCase):
     def test_discovery(self):
         group = self.client.discovery()
         assert group
-        expected = ['unit', 'test', 'list']
-        assert expected
         with requests_mock.Mocker() as m:
-            url = group.api.compute_url('search')
-            m.get(url, json=expected)
-            actual = group.search('whatever')
+            # The search function in this class supports two search
+            # syntaxes so test both.
+            display_name = 'whatever'
+            expected = {'id': 'abcdefg', 'name': display_name}
+            url = group.api.compute_url('search?name=%s' % display_name)
+            m.get(url, json=expected, complete_qs=True)
+            # The old simple search syntax.
+            actual = group.search(display_name)
+            assert actual == expected
+            # The newer query syntax.
+            actual = group.search('name=%s' % display_name)
             assert actual == expected
 
+        with requests_mock.Mocker() as m:
+            thisid = 111111
+            expected = {'id': thisid}
             url = group.api.compute_url()
             m.post(url, json=expected)
             actual = group.create(definition=expected)
             assert actual == expected
 
+        with requests_mock.Mocker() as m:
             thisid = 123456
-            url = group.api.compute_url(thisid)
+            expected = {'id': thisid}
+            url = group.api.compute_url()
             m.post(url, json=expected)
             actual = group.update(definition=expected)
             assert actual == expected
 
+        with requests_mock.Mocker() as m:
             thisid = 789012
+            expected = {'id': thisid}
             url = group.api.compute_url('action/scan/%s' % thisid)
             m.get(url, json=expected)
             actual = group.rescan(uuid=thisid)
             assert actual == expected
 
+        with requests_mock.Mocker() as m:
             thisid = 345678
+            expected = {'id': thisid}
             url = group.api.compute_url(thisid)
             m.delete(url, json=expected)
             actual = group.delete(uuid=thisid)
@@ -102,38 +132,49 @@ class DevmgmtText(unittest.TestCase):
     def test_credential_sets(self):
         group = self.client.credential_sets()
         assert group
-        expected = ['unit', 'test', 'list']
-        assert expected
         with requests_mock.Mocker() as m:
+            thisid = 111111
+            expected = {'id': thisid}
             url = group.api.compute_url()
             m.get(url, json=expected)
             actual = group.get()
             assert actual == expected
 
+        with requests_mock.Mocker() as m:
+            thisid = 222222
+            expected = {'id': thisid}
             url = group.api.compute_url()
             m.post(url, json=expected)
             actual = group.create(definition=expected)
             assert actual == expected
 
+        with requests_mock.Mocker() as m:
             thisid = 123456
+            expected = {'id': thisid}
             url = group.api.compute_url(thisid)
             m.get(url, json=expected)
             actual = group.get(uuid=thisid)
             assert actual == expected
 
+        with requests_mock.Mocker() as m:
             thisid = 789012
+            expected = {'id': thisid}
             url = group.api.compute_url('%s/minimal' % thisid)
             m.get(url, json=expected)
             actual = group.get(uuid=thisid, minimal=True)
             assert actual == expected
 
+        with requests_mock.Mocker() as m:
             thisid = 345678
+            expected = {'id': thisid}
             url = group.api.compute_url(thisid)
             m.post(url, json=expected)
             actual = group.update(uuid=thisid, definition=expected)
             assert actual == expected
 
+        with requests_mock.Mocker() as m:
             thisid = 901234
+            expected = {'id': thisid}
             url = group.api.compute_url(thisid)
             m.delete(url, json=expected)
             actual = group.delete(uuid=thisid)

--- a/tests/test_escalations.py
+++ b/tests/test_escalations.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,65 +36,63 @@ class ApiTest(unittest.TestCase):
 
     def test_search(self):
         group = self.escalations
-        pattern = 'whatever'
-        url = group.api.compute_url('search?%s' % pattern)
-        expected = ['unit', 'test', 'list']
+        thisid = 123456
+        expected = {'id': thisid}
+        pattern = 'queryString=name:Test+allList:true'
         with requests_mock.Mocker() as m:
-            assert expected
-            m.get(url, json=expected)
+            url = group.api.compute_url('search?%s' % pattern)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.search(pattern)
-        assert actual == expected
+            assert actual == expected
 
     def test_create(self):
         group = self.escalations
-        url = group.api.compute_url()
-        expected = {'id': 345678}
+        thisid = 345678
+        expected = {'id': thisid}
+        fake_definition = {'name': 'elvis'}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
-            actual = group.create(definition=expected)
-        assert actual == expected
+            url = group.api.compute_url()
+            m.post(url, json=expected, complete_qs=True)
+            actual = group.create(definition=fake_definition)
+            assert actual == expected
 
     def test_update(self):
         group = self.escalations
         thisid = 123456
-        url = group.api.compute_url(thisid)
         expected = {'id': thisid}
+        fake_definition = {'name': 'elvis'}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
-            actual = group.update(uuid=thisid, definition=expected)
-        assert actual == expected
+            url = group.api.compute_url(thisid)
+            m.post(url, json=expected, complete_qs=True)
+            actual = group.update(uuid=thisid, definition=fake_definition)
+            assert actual == expected
 
     def test_delete(self):
         group = self.escalations
         thisid = 789012
-        url = group.api.compute_url(thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.delete(url, json=expected)
+            url = group.api.compute_url(thisid)
+            m.delete(url, json=expected, complete_qs=True)
             actual = group.delete(uuid=thisid)
-        assert actual == expected
+            assert actual == expected
 
     def test_enable(self):
         group = self.escalations
         thisid = 345678
-        url = group.api.compute_url('%s/enable' % thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
+            url = group.api.compute_url('%s/enable' % thisid)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.enable(uuid=thisid)
-        assert actual == expected
+            assert actual == expected
 
     def test_disable(self):
         group = self.escalations
         thisid = 901234
-        url = group.api.compute_url('%s/disable' % thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
+            url = group.api.compute_url('%s/disable' % thisid)
             m.post(url, json=expected)
             actual = group.disable(uuid=thisid)
-        assert actual == expected
+            assert actual == expected

--- a/tests/test_first_response.py
+++ b/tests/test_first_response.py
@@ -45,71 +45,67 @@ class ApiTest(unittest.TestCase):
             else:
                 url = group.api.compute_url()
             with requests_mock.Mocker() as m:
-                m.get(url, json=expected)
+                m.get(url, json=expected, complete_qs=True)
                 actual = group.search(pattern)
             assert actual == expected
 
     def test_policy_detail(self):
         group = self.first_response
         thisid = 789012
-        url = group.api.compute_url(thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.get(url, json=expected)
+            url = group.api.compute_url(thisid)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.policy_detail(uuid=thisid)
-        assert actual == expected
+            assert actual == expected
 
     def test_create(self):
         group = self.first_response
-        url = group.api.compute_url()
         expected = {'id': 345678}
+        fake_defn = {'name': 'dougal'}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
-            actual = group.create(definition=expected)
-        assert actual == expected
+            url = group.api.compute_url()
+            m.post(url, json=expected, complete_qs=True)
+            actual = group.create(definition=fake_defn)
+            assert actual == expected
 
     def test_update(self):
         group = self.first_response
         thisid = 123456
-        url = group.api.compute_url(thisid)
         expected = {'id': thisid}
+        fake_defn = {'name': 'ted'}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
-            actual = group.update(uuid=thisid, definition=expected)
-        assert actual == expected
+            url = group.api.compute_url(thisid)
+            m.post(url, json=expected, complete_qs=True)
+            actual = group.update(uuid=thisid, definition=fake_defn)
+            assert actual == expected
 
     def test_delete(self):
         group = self.first_response
         thisid = 789012
-        url = group.api.compute_url(thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.delete(url, json=expected)
+            url = group.api.compute_url(thisid)
+            m.delete(url, json=expected, complete_qs=True)
             actual = group.delete(uuid=thisid)
-        assert actual == expected
+            assert actual == expected
 
     def test_enable(self):
         group = self.first_response
         thisid = 345678
-        url = group.api.compute_url('%s/enable' % thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
+            url = group.api.compute_url('%s/enable' % thisid)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.enable(uuid=thisid)
-        assert actual == expected
+            assert actual == expected
 
     def test_disable(self):
         group = self.first_response
         thisid = 901234
-        url = group.api.compute_url('%s/disable' % thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
+            url = group.api.compute_url('%s/disable' % thisid)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.disable(uuid=thisid)
-        assert actual == expected
+            assert actual == expected

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -39,14 +39,14 @@ class InstancesTest(unittest.TestCase):
 
     def test_itypes(self):
         group = self.integs.itypes()
+        thisid = 111111
+        expected = {'id': thisid}
         pattern = 'whatever'
-        url = group.api.compute_url('search?%s' % pattern)
-        expected = ['unit', 'test', 'list']
         with requests_mock.Mocker() as m:
-            assert expected
-            m.get(url, json=expected)
+            url = group.api.compute_url('search?%s' % pattern)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.search(pattern)
-        assert actual == expected
+            assert actual == expected
         # check the compatibility function would return the
         # same type of object, so there's no need to repeat
         # all of the tests for it.
@@ -54,14 +54,14 @@ class InstancesTest(unittest.TestCase):
 
     def test_instances(self):
         group = self.integs.instances()
+        thisid = 222222
+        expected = {'id': thisid}
         pattern = 'whatever'
-        url = group.api.compute_url('search?%s' % pattern)
-        expected = ['unit', 'test', 'list']
         with requests_mock.Mocker() as m:
-            assert expected
-            m.get(url, json=expected)
+            url = group.api.compute_url('search?%s' % pattern)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.search(pattern)
-        assert actual == expected
+            assert actual == expected
         # check the compatibility function would return the
         # same type of object, so there's no need to repeat
         # all of the tests for it.
@@ -70,57 +70,55 @@ class InstancesTest(unittest.TestCase):
     def test_instance_kubernetes_configuration(self):
         group = self.integs.instances()
         thisid = 123456
-        url = group.api.compute_url('%s/configFile/kubernetes' % thisid)
-        expected = [{'unit': 'test'}]
+        expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.get(url, json=expected)
+            url = group.api.compute_url('%s/configFile/kubernetes' % thisid)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.get_kubernetes_configuration(uuid=thisid)
-        assert actual == expected
+            assert actual == expected
 
     def test_instance_create(self):
         group = self.integs.instances()
+        thisid = 789012
+        expected = {'id': thisid}
         name = 'unit-test-integration'
-        url = group.creator_api.compute_url(name)
-        expected = {'unit': 'test'}
+        fake_defn = {'name': 'fr larry duff'}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
-            actual = group.create(type_name=name, definition=expected)
-        assert actual == expected
+            url = group.creator_api.compute_url(name)
+            m.post(url, json=expected, complete_qs=True)
+            actual = group.create(type_name=name, definition=fake_defn)
+            assert actual == expected
 
     def test_instance_update(self):
         group = self.integs.instances()
-        newid = 123456
-        url = group.api.compute_url(newid)
-        expected = {'unit': 'test'}
+        thisid = 123456
+        expected = {'id': thisid}
+        fake_defn = {'name': 'fr paul stone'}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
-            actual = group.update(uuid=newid, definition=expected)
-        assert actual == expected
+            url = group.api.compute_url(thisid)
+            m.post(url, json=expected, complete_qs=True)
+            actual = group.update(uuid=thisid, definition=fake_defn)
+            assert actual == expected
 
     def test_instance_enable(self):
         group = self.integs.instances()
         thisid = 789012
-        url = group.api.compute_url('%s/enable' % thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
+            url = group.api.compute_url('%s/enable' % thisid)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.enable(uuid=thisid)
-        assert actual == expected
+            assert actual == expected
 
     def test_instance_disable(self):
         group = self.integs.instances()
         thisid = 345678
-        url = group.api.compute_url('%s/disable' % thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
+            url = group.api.compute_url('%s/disable' % thisid)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.disable(uuid=thisid)
-        assert actual == expected
+            assert actual == expected
 
     def test_instance_delete(self):
         group = self.integs.instances()
@@ -129,19 +127,20 @@ class InstancesTest(unittest.TestCase):
 
         expected_response = {'id': thisid}
 
-        # Test that a delete works as expected if reason not provided
+        # Test that the delete function inserts a default reason
+        # if we don't provide one.
         expected_send = {"uninstallReason": "<Not specified>"}
         with requests_mock.Mocker() as m:
-            adapter = m.delete(url, json=expected_response)
+            adapter = m.delete(url, json=expected_response, complete_qs=True)
             actual_response = group.delete(uuid=thisid)
             assert adapter.last_request.json() == expected_send
             assert actual_response == expected_response
 
-        # Test that a delete works as expected if we provide a reason
+        # Test that the delete function sends the reason we specified.
         delete_reason = 'Totally fake reason to delete something'
         expected_send = {"uninstallReason": delete_reason}
         with requests_mock.Mocker() as m:
-            adapter = m.delete(url, json=expected_response)
+            adapter = m.delete(url, json=expected_response, complete_qs=True)
             actual_response = group.delete(
                 uuid=thisid,
                 uninstall_reason=delete_reason
@@ -152,26 +151,28 @@ class InstancesTest(unittest.TestCase):
     def test_instance_notifier(self):
         group = self.integs.instances()
         thisid = 901234
-        url = group.api.compute_url('%s/notifier' % thisid)
         expected = {'id': thisid}
+        fake_defn = {'name': 'fr fintan stack'}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
-            actual = group.notifier(uuid=thisid, definition=expected)
-        assert actual == expected
+            url = group.api.compute_url('%s/notifier' % thisid)
+            m.post(url, json=expected, complete_qs=True)
+            actual = group.notifier(uuid=thisid, definition=fake_defn)
+            assert actual == expected
 
     def test_instance_auth_type(self):
         group = self.integs.instances()
         thisid = 567890
         url = group.api.compute_url('%s/inbound/authentication' % thisid)
-        with requests_mock.Mocker() as m:
-            for key in 'OAUTH2', 'WEBHOOK', 'BASIC':
-                expected = {'type': key}
-                m.post(url, json=expected)
+        for key in 'OAUTH2', 'WEBHOOK', 'BASIC':
+            expected = {'type': key}
+            with requests_mock.Mocker() as m:
+                m.post(url, json=expected, complete_qs=True)
                 actual = group.set_auth_type(uuid=thisid, auth_type=key)
                 assert actual == expected
+        with requests_mock.Mocker() as m:
             with self.assertRaises(AssertionError):
                 group.set_auth_type(uuid=thisid, auth_type='unit test value')
+            assert m.call_count == 0
 
     def base_display_name(self, fn):
         with self.assertRaises(AssertionError):

--- a/tests/test_mgmt_profiles.py
+++ b/tests/test_mgmt_profiles.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,70 +35,67 @@ class ApiTest(unittest.TestCase):
         assert 'Profiles' in str(self.group)
 
     def test_search(self):
+        thisid = 111111
+        expected = {'id': thisid}
         pattern = 'whatever'
-        url = self.group.api.compute_url('search?%s' % pattern)
-        expected = ['unit', 'test', 'list']
         with requests_mock.Mocker() as m:
-            assert expected
-            m.get(url, json=expected)
+            url = self.group.api.compute_url('search?%s' % pattern)
+            m.get(url, json=expected, complete_qs=True)
             actual = self.group.search(pattern)
-        assert actual == expected
+            assert actual == expected
 
     def test_create(self):
-        url = self.group.api.compute_url()
-        expected = {'id': 345678}
+        thisid = 345678
+        expected = {'id': thisid}
+        fake_defn = {'name': 'jack'}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
-            actual = self.group.create(definition=expected)
-        assert actual == expected
+            url = self.group.api.compute_url()
+            m.post(url, json=expected, complete_qs=True)
+            actual = self.group.create(definition=fake_defn)
+            assert actual == expected
 
     def test_update(self):
         thisid = 123456
-        url = self.group.api.compute_url(thisid)
         expected = {'id': thisid}
+        fake_defn = {'name': 'mrs doyle'}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
-            actual = self.group.update(uuid=thisid, definition=expected)
-        assert actual == expected
+            url = self.group.api.compute_url(thisid)
+            m.post(url, json=expected, complete_qs=True)
+            actual = self.group.update(uuid=thisid, definition=fake_defn)
+            assert actual == expected
 
     def test_delete(self):
         thisid = 789012
-        url = self.group.api.compute_url(thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.delete(url, json=expected)
+            url = self.group.api.compute_url(thisid)
+            m.delete(url, json=expected, complete_qs=True)
             actual = self.group.delete(uuid=thisid)
-        assert actual == expected
+            assert actual == expected
 
     def test_attach(self):
         thisid = 345678
-        url = self.group.api.compute_url('%s/attach' % thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.get(url, json=expected)
+            url = self.group.api.compute_url('%s/attach' % thisid)
+            m.get(url, json=expected, complete_qs=True)
             actual = self.group.attach(uuid=thisid)
-        assert actual == expected
+            assert actual == expected
 
     def test_detach(self):
         thisid = 901234
-        url = self.group.api.compute_url('%s/detach' % thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.get(url, json=expected)
+            url = self.group.api.compute_url('%s/detach' % thisid)
+            m.get(url, json=expected, complete_qs=True)
             actual = self.group.detach(uuid=thisid)
-        assert actual == expected
+            assert actual == expected
 
     def test_reconnect(self):
         thisid = 901234
-        url = self.group.api.compute_url('%s/reconnectTunnel' % thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.get(url, json=expected)
+            url = self.group.api.compute_url('%s/reconnectTunnel' % thisid)
+            m.get(url, json=expected, complete_qs=True)
             actual = self.group.reconnect(uuid=thisid)
-        assert actual == expected
+            assert actual == expected

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,11 +36,11 @@ class MonitoringTest(unittest.TestCase):
 
     def test_templates(self):
         group = self.monitoring.templates()
-        assert group
-        expected = ['unit', 'test', 'list']
-        assert expected
+        thisid = 888888
+        expected = {'id': thisid}
+        pattern = 'whatever'
         with requests_mock.Mocker() as m:
-            url = group.api.compute_url('search?whatever')
-            m.get(url, json=expected)
-            actual = group.search('whatever')
-        assert actual == expected
+            url = group.api.compute_url('search?%s' % pattern)
+            m.get(url, json=expected, complete_qs=True)
+            actual = group.search(pattern)
+            assert actual == expected

--- a/tests/test_orapi.py
+++ b/tests/test_orapi.py
@@ -48,7 +48,37 @@ class ClassTest(unittest.TestCase):
         assert 'ORapi' in str(self.testobj)
 
     def test_get(self):
+        hdrs = {'fake-header': 'fake-value'}
         expected = 'unit test get result'
         self.mock_ao.get.return_value = expected
-        actual = self.testobj.get(suffix='whatever', headers={})
+
+        suffix = 'milk'
+        actual = self.testobj.get(suffix=suffix, headers=hdrs)
+        self.mock_ao.get.assert_called_with(suffix, hdrs)
+        assert actual == expected
+
+    def test_search(self):
+        hdrs = {'fake-header': 'fake-value'}
+        expected = 'unit test search result'
+        self.mock_ao.get.return_value = expected
+
+        # the leading ? character is optional so try both.
+        qstring = '?name=marmaduke'
+        qs2 = qstring[1:]
+
+        # default suffix should be "search"
+        actual = self.testobj.search(pattern=qstring)
+        self.mock_ao.get.assert_called_with('search' + qstring, None)
+        assert actual == expected
+        actual = self.testobj.search(pattern=qs2, headers=hdrs)
+        self.mock_ao.get.assert_called_with('search' + qstring, hdrs)
+        assert actual == expected
+
+        # try a different suffix
+        suffix = 'toraiocht'
+        actual = self.testobj.search(pattern=qstring, suffix=suffix)
+        self.mock_ao.get.assert_called_with(suffix + qstring, None)
+        assert actual == expected
+        actual = self.testobj.search(pattern=qs2, headers=hdrs, suffix=suffix)
+        self.mock_ao.get.assert_called_with(suffix + qstring, hdrs)
         assert actual == expected

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -68,15 +68,6 @@ class ApiTest(unittest.TestCase):
         self.client = self.ormp.tenant(self.fake_client_id)
         assert self.client.is_client()
 
-    def test_get(self):
-        group = self.client.resources()
-        fake_result = ['unit', 'test', 'get']
-        with requests_mock.Mocker() as m:
-            url = group.api.compute_url()
-            m.get(url, json=fake_result)
-            actual = group.get()
-            assert actual == fake_result
-
     def test_create(self):
         group = self.client.resources()
         fake_create_json = {
@@ -87,10 +78,11 @@ class ApiTest(unittest.TestCase):
             'os': 'Ubuntu 14.04.6 LTS',
             'serialNumber': '1234-5678-901234'
         }
-        fake_result = ['unit', 'test', 'create', 'result']
+        thisid = 333333
+        fake_result = {'id': thisid}
         with requests_mock.Mocker() as m:
             url = group.api.compute_url()
-            m.post(url, json=fake_result)
+            m.post(url, json=fake_result, complete_qs=True)
             actual = group.create(definition=fake_create_json)
             assert actual == fake_result
 
@@ -100,10 +92,10 @@ class ApiTest(unittest.TestCase):
         fake_update_json = {
             'os': 'Ubuntu 18.04.4 LTS'
         }
-        fake_result = ['unit', 'test', 'update', 'result']
+        fake_result = {'id': fake_resource_id}
         with requests_mock.Mocker() as m:
             url = group.api.compute_url(fake_resource_id)
-            m.post(url, json=fake_result)
+            m.post(url, json=fake_result, complete_qs=True)
             actual = group.update(
                 uuid=fake_resource_id,
                 definition=fake_update_json
@@ -113,17 +105,22 @@ class ApiTest(unittest.TestCase):
     def test_delete(self):
         group = self.client.resources()
         fake_resource_id = '789012'
-        fake_result = ['unit', 'test', 'delete', 'result']
+        fake_result = {'id': fake_resource_id}
         with requests_mock.Mocker() as m:
             url = group.api.compute_url(fake_resource_id)
-            m.delete(url, json=fake_result)
+            m.delete(url, json=fake_result, complete_qs=True)
             actual = group.delete(uuid=fake_resource_id)
             assert actual == fake_result
 
     def test_search(self):
+        # The OpsRamp "resources" API returns flat lists of results
+        # instead of the usual multi-value result struct, for no
+        # apparent reason. Our Python classes are supposed to handle
+        # that and return a normal result struct so that the caller
+        # doesn't need to know. Check that it's doing this.
         group = self.client.resources()
         fake_search_pattern = 'queryString=agentInstalled:true'
-        fake_raw_result = ['unit', 'test', 'search', 'result']
+        fake_raw_result = ['unit', 'test', 'search', 'values']
         count = len(fake_raw_result)
         fake_cooked_result = {
             'totalResults': count,
@@ -138,11 +135,16 @@ class ApiTest(unittest.TestCase):
         with requests_mock.Mocker() as m:
             url_suffix = 'search?{0}'.format(fake_search_pattern)
             url = group.api.compute_url(url_suffix)
-            m.get(url, json=fake_raw_result)
+            m.get(url, json=fake_raw_result, complete_qs=True)
             actual = group.search(pattern=fake_search_pattern)
             assert actual == fake_cooked_result
 
     def test_minimal(self):
+        # The OpsRamp "resources" API returns flat lists of results
+        # instead of the usual multi-value result struct, for no
+        # apparent reason. Our Python classes are supposed to handle
+        # that and return a normal result struct so that the caller
+        # doesn't need to know. Check that it's doing this.
         group = self.client.resources()
         fake_search_pattern = 'queryString=agentInstalled:true'
         fake_raw_result = ['unit', 'test', 'minimal', 'result']
@@ -160,11 +162,16 @@ class ApiTest(unittest.TestCase):
         with requests_mock.Mocker() as m:
             url_suffix = 'minimal?{0}'.format(fake_search_pattern)
             url = group.api.compute_url(url_suffix)
-            m.get(url, json=fake_raw_result)
+            m.get(url, json=fake_raw_result, complete_qs=True)
             actual = group.minimal(pattern=fake_search_pattern)
             assert actual == fake_cooked_result
 
     def test_applications(self):
+        # The OpsRamp "resources" API returns flat lists of results
+        # instead of the usual multi-value result struct, for no
+        # apparent reason. Our Python classes are supposed to handle
+        # that and return a normal result struct so that the caller
+        # doesn't need to know. Check that it's doing this.
         group = self.client.resources()
         fake_resource_id = '789012'
         fake_raw_result = ['unit', 'test', 'applications', 'result']
@@ -182,7 +189,7 @@ class ApiTest(unittest.TestCase):
         with requests_mock.Mocker() as m:
             url_suffix = '{0}/applications'.format(fake_resource_id)
             url = group.api.compute_url(url_suffix)
-            m.get(url, json=fake_raw_result)
+            m.get(url, json=fake_raw_result, complete_qs=True)
             actual = group.applications(uuid=fake_resource_id)
             assert actual == fake_cooked_result
 
@@ -199,7 +206,7 @@ class ApiTest(unittest.TestCase):
                 fake_resource_id, fake_start, fake_end
             )
             url = group.api.compute_url(url_suffix)
-            m.get(url, json=fake_result)
+            m.get(url, json=fake_result, complete_qs=True)
             actual = group.availability(
                 uuid=fake_resource_id,
                 start_epoch=fake_start,

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -37,69 +37,56 @@ class ApiTest(unittest.TestCase):
         self.roles = self.client.roles()
         assert 'Roles' in str(self.roles)
 
-    def test_permission_sets_get(self):
-        group = self.permission_sets
-        url = group.api.compute_url()
-        expected = ['unit', 'test', 'list']
-        with requests_mock.Mocker() as m:
-            m.get(url, json=expected)
-            actual = group.get()
-        assert actual == expected
-
     def test_permission_sets_search(self):
         group = self.permission_sets
-        for pattern, expected in (
-            ('', ['unit', 'test', 'results']),
-            ('pageNo=1&pageSize=100&is&sortName=id', ['more', 'nonsense'])
-        ):
-            if pattern:
-                url = group.api.compute_url('?' + pattern)
-            else:
-                url = group.api.compute_url()
-            with requests_mock.Mocker() as m:
-                m.get(url, json=expected)
-                actual = group.search(pattern)
+        thisid = 111111
+        expected = {'id': thisid}
+        pattern = 'whatever'
+        with requests_mock.Mocker() as m:
+            url = group.api.compute_url('?%s' % pattern)
+            m.get(url, json=expected, complete_qs=True)
+            actual = group.search(pattern)
             assert actual == expected
 
     def test_role_search(self):
         group = self.roles
+        thisid = 222222
+        expected = {'id': thisid}
         pattern = 'whatever'
-        url = group.api.compute_url('search?%s' % pattern)
-        expected = ['unit', 'test', 'list']
         with requests_mock.Mocker() as m:
-            assert expected
-            m.get(url, json=expected)
+            url = group.api.compute_url('search?%s' % pattern)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.search(pattern)
-        assert actual == expected
+            assert actual == expected
 
     def test_role_create(self):
         group = self.roles
-        url = group.api.compute_url()
-        expected = {'id': 345678}
+        thisid = 345678
+        expected = {'id': thisid}
+        fake_defn = {'name': 'bishop brennan'}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
-            actual = group.create(definition=expected)
-        assert actual == expected
+            url = group.api.compute_url()
+            m.post(url, json=expected, complete_qs=True)
+            actual = group.create(definition=fake_defn)
+            assert actual == expected
 
     def test_role_update(self):
         group = self.roles
         thisid = 123456
-        url = group.api.compute_url(thisid)
         expected = {'id': thisid}
+        fake_defn = {'name': 'fr noel furlong'}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
-            actual = group.update(uuid=thisid, definition=expected)
-        assert actual == expected
+            url = group.api.compute_url(thisid)
+            m.post(url, json=expected, complete_qs=True)
+            actual = group.update(uuid=thisid, definition=fake_defn)
+            assert actual == expected
 
     def test_role_delete(self):
         group = self.roles
         thisid = 789012
-        url = group.api.compute_url(thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.delete(url, json=expected)
+            url = group.api.compute_url(thisid)
+            m.delete(url, json=expected, complete_qs=True)
             actual = group.delete(uuid=thisid)
         assert actual == expected

--- a/tests/test_service_maps.py
+++ b/tests/test_service_maps.py
@@ -36,22 +36,22 @@ class ApiTest(unittest.TestCase):
 
     def test_service_maps_get_root(self):
         group = self.service_maps
-        url = group.api.compute_url('search')
-        expected = ['unit', 'test', 'list']
+        thisid = 111111
+        expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.get(url, json=expected)
+            url = group.api.compute_url('search')
+            m.get(url, json=expected, complete_qs=True)
             actual = group.get()
-        assert actual == expected
+            assert actual == expected
 
     def test_service_maps_get_child(self):
         group = self.service_maps
+        thisid = 222222
+        expected = {'id': thisid}
         sgid = 'some-sgid'
-        url = group.api.compute_url('%s/childs/search' % sgid)
-        expected = ['unit', 'test', 'list']
         with requests_mock.Mocker() as m:
-            assert expected
-            m.get(url, json=expected)
+            url = group.api.compute_url('%s/childs/search' % sgid)
+            m.get(url, json=expected, complete_qs=True)
             # test uuid parameter specifically.
             actual = group.get(uuid=sgid)
             assert actual == expected
@@ -61,42 +61,42 @@ class ApiTest(unittest.TestCase):
 
     def test_service_maps_get_minimal(self):
         group = self.service_maps
-        url = group.api.compute_url('minimal')
-        expected = ['unit', 'test', 'list']
+        thisid = 333333
+        expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.get(url, json=expected)
+            url = group.api.compute_url('minimal')
+            m.get(url, json=expected, complete_qs=True)
             actual = group.get(minimal=True)
-        assert actual == expected
+            assert actual == expected
 
     def test_service_maps_create(self):
         group = self.service_maps
-        url = group.api.compute_url()
-        expected = {'id': 345678}
+        thisid = 444444
+        expected = {'id': thisid}
+        fake_defn = {'name': 'fr dick byrne'}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
-            actual = group.create(definition=expected)
-        assert actual == expected
+            url = group.api.compute_url()
+            m.post(url, json=expected, complete_qs=True)
+            actual = group.create(definition=fake_defn)
+            assert actual == expected
 
     def test_service_maps_update(self):
         group = self.service_maps
         thisid = 123456
-        url = group.api.compute_url(thisid)
         expected = {'id': thisid}
+        fake_defn = {'name': 'fr todd unctious'}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
-            actual = group.update(uuid=thisid, definition=expected)
-        assert actual == expected
+            url = group.api.compute_url(thisid)
+            m.post(url, json=expected, complete_qs=True)
+            actual = group.update(uuid=thisid, definition=fake_defn)
+            assert actual == expected
 
     def test_service_maps_delete(self):
         group = self.service_maps
         thisid = 789012
-        url = group.api.compute_url(thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.delete(url, json=expected)
+            url = group.api.compute_url(thisid)
+            m.delete(url, json=expected, complete_qs=True)
             actual = group.delete(uuid=thisid)
-        assert actual == expected
+            assert actual == expected

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,63 +36,63 @@ class ApiTest(unittest.TestCase):
 
     def test_site_search(self):
         group = self.sites
+        thisid = 123456
+        expected = {'id': thisid}
         pattern = 'whatever'
-        url = group.api.compute_url('search?%s' % pattern)
-        expected = ['unit', 'test', 'list']
         with requests_mock.Mocker() as m:
-            assert expected
-            m.get(url, json=expected)
+            url = group.api.compute_url('search?%s' % pattern)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.search(pattern)
-        assert actual == expected
+            assert actual == expected
 
     def test_site_create(self):
         group = self.sites
-        url = group.api.compute_url()
         expected = {'id': 345678}
+        fake_defn = {'name': 'fr cyril mcduff'}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
-            actual = group.create(definition=expected)
-        assert actual == expected
+            url = group.api.compute_url()
+            m.post(url, json=expected, complete_qs=True)
+            actual = group.create(definition=fake_defn)
+            assert actual == expected
 
     def test_site_update(self):
         group = self.sites
         thisid = 123456
-        url = group.api.compute_url(thisid)
         expected = {'id': thisid}
+        fake_defn = {'name': 'fr cyril mcduff'}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.post(url, json=expected)
-            actual = group.update(uuid=thisid, definition=expected)
-        assert actual == expected
+            url = group.api.compute_url(thisid)
+            m.post(url, json=expected, complete_qs=True)
+            actual = group.update(uuid=thisid, definition=fake_defn)
+            assert actual == expected
 
     def test_site_delete(self):
         group = self.sites
         thisid = 789012
-        url = group.api.compute_url(thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            assert expected
-            m.delete(url, json=expected)
+            url = group.api.compute_url(thisid)
+            m.delete(url, json=expected, complete_qs=True)
             actual = group.delete(uuid=thisid)
-        assert actual == expected
+            assert actual == expected
 
     def test_site_get_id(self):
         group = self.sites
         thisid = 345678
-        url = group.api.compute_url(thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            m.get(url, json=expected)
+            url = group.api.compute_url(thisid)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.get(thisid)
             assert actual == expected
 
     def test_site_get_list(self):
         group = self.sites
-        url = group.api.compute_url('minimal')
-        expected = ['unit', 'test', 'list']
+        thisid = 901234
+        expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            m.get(url, json=expected)
+            url = group.api.compute_url('minimal')
+            m.get(url, json=expected, complete_qs=True)
             # default suffix should be "minimal"
             actual = group.get()
             assert actual == expected


### PR DESCRIPTION
Many classes have their own "search" functions but most of them are
identical so it makes sense to move into the base class and override
the minority that need to behave differently.

Change the unit tests to accommodate that, but also refactor some of
them to avoid reusing the requests_mock object because that can hide
issues where a test is succeeding only because a previous one has
primed the mock for it.