### PR TITLE
Introduce the ORapi class above ApiWrapper

### DIFF
--- a/opsramp/api.py
+++ b/opsramp/api.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#
+# A minimal Python language binding for the OpsRamp REST API.
+#
+# api.py
+# OpsRamp-specific variant of ApiWrapper base class as a container for
+# some methods and helpers that are common to multiple parts of that API.
+#
+# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import base64
+
+from opsramp.base import ApiWrapper
+
+
+class ORapi(ApiWrapper):
+    '''OpsRamp-specific variant of ApiWrapper base class as a container for
+    some methods and helpers that are common to multiple parts of that API.'''
+
+    # Returns a string containing a base64 encoded version of the
+    # content of the specified file. It was quite finicky to come
+    # up with a method that works on both Python 2 and 3 so please
+    # don't modify this, or test carefully if you do.
+    @staticmethod
+    def b64encode_payload(fname):
+        with open(fname, 'rb') as f:
+            content = base64.b64encode(f.read())
+        return content.decode()
+
+    def get(self, suffix='', headers=None):
+        return self.api.get(suffix, headers)

--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -21,7 +21,6 @@
 # limitations under the License.
 
 from __future__ import print_function
-import base64
 import requests
 try:
     # Python 3
@@ -34,16 +33,6 @@ except ImportError:
 
 
 class Helpers(object):
-    # Returns a string containing a base64 encoded version of the
-    # content of the specified file. It was quite finicky to come
-    # up with a method that works on both Python 2 and 3 so please
-    # don't modify this, or test carefully if you do.
-    @staticmethod
-    def b64encode_payload(fname):
-        with open(fname, 'rb') as f:
-            content = base64.b64encode(f.read())
-        return content.decode()
-
     # (DW) Add support for retries of requests to the OpsRamp API in the event
     # of receiving a HTTP 429 (Too Many Requests) response from the API to
     # suggest that it has activated rate limiting. This implements progressive
@@ -316,6 +305,3 @@ class ApiWrapper(object):
 
     def __str__(self):
         return '%s %s' % (str(type(self)), self.api)
-
-    def get(self, suffix='', headers=None):
-        return self.api.get(suffix, headers)

--- a/opsramp/binding.py
+++ b/opsramp/binding.py
@@ -5,7 +5,7 @@
 # binding.py
 # Defines the primary entry points for callers of this library.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,8 @@
 
 from __future__ import print_function
 
-from opsramp.base import ApiObject, ApiWrapper
+from opsramp.base import ApiObject
+from opsramp.api import ORapi
 from opsramp.globalconfig import GlobalConfig
 from opsramp.tenant import Tenant
 
@@ -41,7 +42,7 @@ def connect(url, key, secret):
     return Opsramp(url, token)
 
 
-class Opsramp(ApiWrapper):
+class Opsramp(ORapi):
     def __init__(self, url, token):
         self.auth = {
             'Authorization': 'Bearer ' + token,

--- a/opsramp/devmgmt.py
+++ b/opsramp/devmgmt.py
@@ -20,10 +20,10 @@
 # limitations under the License.
 
 from __future__ import print_function
-from opsramp.base import ApiWrapper
+from opsramp.api import ORapi
 
 
-class Policies(ApiWrapper):
+class Policies(ORapi):
     def __init__(self, parent):
         super(Policies, self).__init__(parent.api, 'policies/management')
 
@@ -46,7 +46,7 @@ class Policies(ApiWrapper):
         return self.api.delete('%s' % uuid)
 
 
-class Discovery(ApiWrapper):
+class Discovery(ORapi):
     def __init__(self, parent):
         assert parent.is_client()
         super(Discovery, self).__init__(parent.api, 'policies/discovery')
@@ -70,7 +70,7 @@ class Discovery(ApiWrapper):
         return self.api.delete('/%s' % uuid)
 
 
-class CredentialSets(ApiWrapper):
+class CredentialSets(ORapi):
     def __init__(self, parent):
         super(CredentialSets, self).__init__(parent.api, 'credentialSets')
 

--- a/opsramp/escalations.py
+++ b/opsramp/escalations.py
@@ -20,10 +20,10 @@
 # limitations under the License.
 
 from __future__ import print_function
-from opsramp.base import ApiWrapper
+from opsramp.api import ORapi
 
 
-class Escalations(ApiWrapper):
+class Escalations(ORapi):
     def __init__(self, parent):
         super(Escalations, self).__init__(parent.api, 'escalations')
 

--- a/opsramp/first_response.py
+++ b/opsramp/first_response.py
@@ -20,10 +20,10 @@
 # limitations under the License.
 
 from __future__ import print_function
-from opsramp.base import ApiWrapper
+from opsramp.api import ORapi
 
 
-class First_Response(ApiWrapper):
+class First_Response(ORapi):
     def __init__(self, parent):
         super(First_Response, self).__init__(parent.api,
                                              'policies/firstResponse')

--- a/opsramp/globalconfig.py
+++ b/opsramp/globalconfig.py
@@ -4,7 +4,7 @@
 #
 # globalconfig.py
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,10 +19,10 @@
 # limitations under the License.
 
 from __future__ import print_function
-from opsramp.base import ApiWrapper
+from opsramp.api import ORapi
 
 
-class GlobalConfig(ApiWrapper):
+class GlobalConfig(ORapi):
     def __init__(self, parent):
         super(GlobalConfig, self).__init__(parent.api, '')
 

--- a/opsramp/integrations.py
+++ b/opsramp/integrations.py
@@ -21,7 +21,8 @@
 
 from __future__ import print_function
 import os
-from opsramp.base import ApiWrapper, Helpers
+
+from opsramp.api import ORapi
 
 '''
 POST install/{intgld} e.g. CUSTOM
@@ -43,7 +44,7 @@ GET available/{intgld}/mappingAttr/{entityType}
 '''
 
 
-class Integrations(ApiWrapper):
+class Integrations(ORapi):
     def __init__(self, parent):
         super(Integrations, self).__init__(parent.api, 'integrations')
 
@@ -64,7 +65,7 @@ class Integrations(ApiWrapper):
         return self.instances()
 
 
-class Types(ApiWrapper):
+class Types(ORapi):
     def __init__(self, parent):
         super(Types, self).__init__(parent.api, 'available')
 
@@ -75,7 +76,7 @@ class Types(ApiWrapper):
         return self.api.get(suffix)
 
 
-class Instances(ApiWrapper):
+class Instances(ORapi):
     def __init__(self, parent):
         super(Instances, self).__init__(parent.api, 'installed')
         # The OpsRamp "create instance" API endpoint is in an
@@ -161,7 +162,7 @@ class Instances(ApiWrapper):
             'displayName': display_name,
         }
         if logo_fname:
-            payload = Helpers.b64encode_payload(logo_fname)
+            payload = ORapi.b64encode_payload(logo_fname)
             retval['logo'] = {
                 'name': os.path.basename(logo_fname),
                 'file': payload

--- a/opsramp/kb.py
+++ b/opsramp/kb.py
@@ -21,10 +21,10 @@
 # limitations under the License.
 
 from __future__ import print_function
-from opsramp.base import ApiWrapper
+from opsramp.api import ORapi
 
 
-class KnowledgeBase(ApiWrapper):
+class KnowledgeBase(ORapi):
     def __init__(self, parent):
         super(KnowledgeBase, self).__init__(parent.api, 'kb')
 
@@ -38,7 +38,7 @@ class KnowledgeBase(ApiWrapper):
         return KBtemplates(self)
 
 
-class KBcategories(ApiWrapper):
+class KBcategories(ORapi):
     def __init__(self, parent):
         super(KBcategories, self).__init__(parent.api, 'category')
         # weirdly, calls to "categorylist" need to be made at "kb" level
@@ -72,7 +72,7 @@ class KBcategories(ApiWrapper):
         return self.api.post('restore/%s' % uuid)
 
 
-class KBarticles(ApiWrapper):
+class KBarticles(ORapi):
     def __init__(self, parent):
         super(KBarticles, self).__init__(parent.api, 'article')
         # weirdly, calls to "articlesList" need to be made at "kb" level
@@ -103,7 +103,7 @@ class KBarticles(ApiWrapper):
         return self.api.get('%s/comments' % uuid)
 
 
-class KBtemplates(ApiWrapper):
+class KBtemplates(ORapi):
     def __init__(self, parent):
         super(KBtemplates, self).__init__(parent.api, 'template')
         # weirdly, calls to "templatesList" need to be made at "kb" level

--- a/opsramp/mgmt_profiles.py
+++ b/opsramp/mgmt_profiles.py
@@ -6,7 +6,7 @@
 # Classes dealing directly with OpsRamp Management Profiles.
 # The are used for interactions with gateway nodes.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,10 +21,10 @@
 # limitations under the License.
 
 from __future__ import print_function
-from opsramp.base import ApiWrapper
+from opsramp.api import ORapi
 
 
-class Profiles(ApiWrapper):
+class Profiles(ORapi):
     def __init__(self, parent):
         super(Profiles, self).__init__(parent.api, 'managementProfiles')
 

--- a/opsramp/monitoring.py
+++ b/opsramp/monitoring.py
@@ -20,10 +20,10 @@
 # limitations under the License.
 
 from __future__ import print_function
-from opsramp.base import ApiWrapper
+from opsramp.api import ORapi
 
 
-class Monitoring(ApiWrapper):
+class Monitoring(ORapi):
     def __init__(self, parent):
         super(Monitoring, self).__init__(parent.api, 'monitoring')
 
@@ -31,7 +31,7 @@ class Monitoring(ApiWrapper):
         return Templates(self)
 
 
-class Templates(ApiWrapper):
+class Templates(ORapi):
     def __init__(self, parent):
         super(Templates, self).__init__(parent.api, 'templates')
 

--- a/opsramp/msp.py
+++ b/opsramp/msp.py
@@ -21,10 +21,10 @@
 
 from __future__ import print_function
 import datetime
-from opsramp.base import ApiWrapper
+from opsramp.api import ORapi
 
 
-class Clients(ApiWrapper):
+class Clients(ORapi):
     def __init__(self, parent):
         super(Clients, self).__init__(parent.api, 'clients')
 

--- a/opsramp/rba.py
+++ b/opsramp/rba.py
@@ -21,10 +21,10 @@
 
 from __future__ import print_function
 
-from opsramp.base import ApiWrapper, Helpers
+from opsramp.api import ORapi
 
 
-class Rba(ApiWrapper):
+class Rba(ORapi):
     def __init__(self, parent):
         super(Rba, self).__init__(parent.api, 'rba')
 
@@ -32,7 +32,7 @@ class Rba(ApiWrapper):
         return Categories(self)
 
 
-class Categories(ApiWrapper):
+class Categories(ORapi):
     def __init__(self, parent):
         super(Categories, self).__init__(parent.api, 'categories')
 
@@ -60,7 +60,7 @@ class Categories(ApiWrapper):
         return self.api.delete('%s' % uuid)
 
 
-class Category(ApiWrapper):
+class Category(ORapi):
     def __init__(self, parent, uuid):
         super(Category, self).__init__(parent.api, '%s/scripts' % uuid)
 
@@ -125,7 +125,7 @@ class Category(ApiWrapper):
         assert execution_type
         if payload_file:
             assert not payload
-            payload = Helpers.b64encode_payload(payload_file)
+            payload = ORapi.b64encode_payload(payload_file)
         assert payload
         if execution_type not in ('DOWNLOAD', 'EXE', 'MSI'):
             assert not output_directory

--- a/opsramp/resources.py
+++ b/opsramp/resources.py
@@ -20,7 +20,7 @@
 # limitations under the License.
 
 from __future__ import print_function
-from opsramp.base import ApiWrapper
+from opsramp.api import ORapi
 
 
 def list2ormp(result_obj):
@@ -47,7 +47,7 @@ def list2ormp(result_obj):
     return retval
 
 
-class Resources(ApiWrapper):
+class Resources(ORapi):
     def __init__(self, parent):
         super(Resources, self).__init__(parent.api, 'resources')
 

--- a/opsramp/roles.py
+++ b/opsramp/roles.py
@@ -20,10 +20,10 @@
 # limitations under the License.
 
 from __future__ import print_function
-from opsramp.base import ApiWrapper
+from opsramp.api import ORapi
 
 
-class Roles(ApiWrapper):
+class Roles(ORapi):
     def __init__(self, parent):
         super(Roles, self).__init__(parent.api, 'roles')
 
@@ -43,7 +43,7 @@ class Roles(ApiWrapper):
         return self.api.delete('%s' % uuid)
 
 
-class PermissionSets(ApiWrapper):
+class PermissionSets(ORapi):
     def __init__(self, parent):
         super(PermissionSets, self).__init__(parent.api, 'permissionSets')
 

--- a/opsramp/service_maps.py
+++ b/opsramp/service_maps.py
@@ -22,10 +22,10 @@
 # limitations under the License.
 
 from __future__ import print_function
-from opsramp.base import ApiWrapper
+from opsramp.api import ORapi
 
 
-class ServiceMaps(ApiWrapper):
+class ServiceMaps(ORapi):
     def __init__(self, parent):
         super(ServiceMaps, self).__init__(parent.api, 'serviceGroups')
 

--- a/opsramp/sites.py
+++ b/opsramp/sites.py
@@ -21,10 +21,10 @@
 # limitations under the License.
 
 from __future__ import print_function
-from opsramp.base import ApiWrapper
+from opsramp.api import ORapi
 
 
-class Sites(ApiWrapper):
+class Sites(ORapi):
     def __init__(self, parent):
         super(Sites, self).__init__(parent.api, 'sites')
 

--- a/opsramp/tenant.py
+++ b/opsramp/tenant.py
@@ -21,7 +21,7 @@
 
 from __future__ import print_function
 
-from opsramp.base import ApiWrapper
+from opsramp.api import ORapi
 import opsramp.rba
 import opsramp.monitoring
 import opsramp.msp
@@ -37,7 +37,7 @@ import opsramp.resources
 import opsramp.first_response
 
 
-class Tenant(ApiWrapper):
+class Tenant(ORapi):
     def __init__(self, parent, uuid):
         super(Tenant, self).__init__(parent.api, 'tenants/%s' % uuid)
         self.uuid = uuid

--- a/tests/test_api_class.py
+++ b/tests/test_api_class.py
@@ -25,7 +25,7 @@ import requests_mock
 # types of exceptions, not exceptions from the generic "json" module.
 import simplejson
 
-import opsramp.binding
+import opsramp.base
 
 
 class FakeResp(object):
@@ -52,12 +52,12 @@ class ApiObjectTest(unittest.TestCase):
             'Authorization': 'Bearer %s' % self.fake_token,
             'Accept': 'application/json'
         }
-        self.ao = opsramp.binding.ApiObject(
+        self.ao = opsramp.base.ApiObject(
             self.fake_url,
             self.fake_auth.copy()
         )
         assert 'ApiObject' in str(self.ao)
-        self.awrapper = opsramp.binding.ApiWrapper(self.ao, 'whatevs')
+        self.awrapper = opsramp.base.ApiWrapper(self.ao, 'whatevs')
         assert 'ApiWrapper' in str(self.awrapper)
 
     def test_shared_session(self):
@@ -305,20 +305,4 @@ class ApiObjectTest(unittest.TestCase):
             expected = 'unit test patch result'
             m.patch(url, text=expected)
             actual = self.ao.patch()
-            assert actual == expected
-
-    # We're not testing an exhaustive set of suffix patterns here because
-    # that is already being done by the ApiObject unit tests. Just
-    # get() and get(something) is enough.
-    def test_wrapped_get(self):
-        with requests_mock.Mocker() as m:
-            url = self.awrapper.api.compute_url()
-            expected = 'unit test wrapped get result'
-            m.get(url, text=expected)
-            actual = self.awrapper.get()
-            assert actual == expected
-            suffix = 'some/where/random'
-            url = self.awrapper.api.compute_url(suffix)
-            m.get(url, text=expected)
-            actual = self.awrapper.get(suffix)
             assert actual == expected

--- a/tests/test_orapi.py
+++ b/tests/test_orapi.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+#
+# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import unittest
+import base64
+from mock import MagicMock
+
+from opsramp.api import ORapi
+
+
+class StaticsTest(unittest.TestCase):
+    def check64(self, testfile):
+        with open(testfile, 'rb') as f:
+            content_raw = f.read()
+        content_64 = ORapi.b64encode_payload(testfile)
+        # decode this result and check against the actual content.
+        decoded = base64.b64decode(content_64)
+        return decoded == content_raw
+
+    def test_base64(self):
+        # a file that is guaranteed to be empty.
+        assert self.check64('/dev/null')
+        # any non-empty file that we know will exist.
+        assert self.check64('setup.py')
+
+
+class ClassTest(unittest.TestCase):
+    def setUp(self):
+        self.mock_ao = MagicMock()
+        self.mock_ao.clone.return_value = self.mock_ao
+        self.testobj = ORapi(self.mock_ao)
+
+    def test_str(self):
+        assert 'ORapi' in str(self.testobj)
+
+    def test_get(self):
+        expected = 'unit test get result'
+        self.mock_ao.get.return_value = expected
+        actual = self.testobj.get(suffix='whatever', headers={})
+        assert actual == expected

--- a/tests/test_retry_logic.py
+++ b/tests/test_retry_logic.py
@@ -193,7 +193,7 @@ class TestMockServer(unittest.TestCase):
 
         api_endpoint = "foo"
         with captured_output() as (out, err):
-            api_wrapper.get("/%s" % api_endpoint)
+            api_wrapper.api.get("/%s" % api_endpoint)
 
         expected_requests = []
         for resp in CANNED_RESPONSES:

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,23 +16,26 @@
 
 from __future__ import print_function
 import unittest
-import base64
 import requests_mock
 
-from opsramp.base import Helpers
+from opsramp.api import ORapi
 from opsramp.rba import Category
 import opsramp.binding
 
 
 class StaticsTest(unittest.TestCase):
     def setUp(self):
-        self.testfile = 'tox.ini'
+        # Several of the tests need a filename, its contents and
+        # the base64 encoded version, so compute all of that up
+        # front and store the data for later use. The actual
+        # contents are not important so use any file that we know
+        # will exist.
+        self.testfile = 'setup.py'
         with open(self.testfile, 'rb') as f:
             self.content_raw = f.read()
-        self.content_64 = Helpers.b64encode_payload(self.testfile)
-        # assert that base64 encoding is working.
-        raw = base64.b64decode(self.content_64)
-        assert raw == self.content_raw
+        # check it's not empty.
+        assert self.content_raw
+        self.content_64 = ORapi.b64encode_payload(self.testfile)
 
     def test_mkAttachment(self):
         tvalues = {


### PR DESCRIPTION
The ApiWrapper class was intended to be a general base class for API
access but over time it has acquired some OpsRamp-specific methods.
Change this by moving those methods into a new subclass ORapi and
making that the parent of the OpsRamp-specific classes instead.