### PR TITLE
Move get() back to ApiWrapper class

### DIFF
--- a/opsramp/api.py
+++ b/opsramp/api.py
@@ -40,9 +40,6 @@ class ORapi(ApiWrapper):
             content = base64.b64encode(f.read())
         return content.decode()
 
-    def get(self, suffix='', headers=None):
-        return self.api.get(suffix, headers)
-
     def search(self, pattern='', headers=None, suffix='search'):
         if pattern:
             if pattern[0] != '?':

--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -305,3 +305,6 @@ class ApiWrapper(object):
 
     def __str__(self):
         return '%s %s' % (str(type(self)), self.api)
+
+    def get(self, suffix='', headers=None):
+        return self.api.get(suffix, headers)

--- a/tests/test_api_class.py
+++ b/tests/test_api_class.py
@@ -306,3 +306,20 @@ class ApiObjectTest(unittest.TestCase):
             m.patch(url, text=expected)
             actual = self.ao.patch()
             assert actual == expected
+
+    # We're not testing an exhaustive set of suffix patterns here because
+    # that is already being done by the ApiObject unit tests. Just
+    # get() and get(something) is enough.
+    def test_wrapped_get(self):
+        with requests_mock.Mocker() as m:
+            url = self.awrapper.api.compute_url()
+            expected = 'unit test wrapped get result'
+            m.get(url, text=expected, complete_qs=True)
+            actual = self.awrapper.get()
+            assert actual == expected
+        with requests_mock.Mocker() as m:
+            suffix = 'some/where/random'
+            url = self.awrapper.api.compute_url(suffix)
+            m.get(url, text=expected, complete_qs=True)
+            actual = self.awrapper.get(suffix)
+            assert actual == expected


### PR DESCRIPTION
On second thoughts it is architecturally valid since this function
has no specific ties to OpsRamp, it's just a REST get call. Also
this restores backwards compatibility which was not necessary to
sacrifice unless really important.