### PR TITLE
Allow empty string and None as suffixes in ApiObject

### DIFF
--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -97,7 +97,8 @@ class PathTracker(object):
         new1.stack = self.stack
         return new1
 
-    def cd(self, path):
+    def cd(self, path=None):
+        path = str(path or '/')
         # no support for '..' right now, maybe in the future
         if path[0] == '/':
             self.prefix = path
@@ -106,7 +107,7 @@ class PathTracker(object):
         self.prefix = self.prefix.strip('/')
         return self.prefix
 
-    def pushd(self, path):
+    def pushd(self, path=None):
         self.stack.append(self.prefix)
         return self.cd(path)
 
@@ -114,8 +115,8 @@ class PathTracker(object):
         self.prefix = self.stack.pop()
         return self.prefix
 
-    def fullpath(self, suffix=''):
-        suffix = str(suffix)
+    def fullpath(self, suffix=None):
+        suffix = str(suffix or '')
         if len(suffix) > 0 and suffix[0] == '/':
             retval = suffix
         else:
@@ -152,11 +153,11 @@ class ApiObject(object):
         )
         return new1
 
-    def cd(self, path):
+    def cd(self, path=None):
         self.tracker.cd(path)
         return self.compute_url()
 
-    def pushd(self, path):
+    def pushd(self, path=None):
         self.tracker.pushd(path)
         return self.compute_url()
 
@@ -306,5 +307,5 @@ class ApiWrapper(object):
     def __str__(self):
         return '%s %s' % (str(type(self)), self.api)
 
-    def get(self, suffix='', headers=None):
+    def get(self, suffix=None, headers=None):
         return self.api.get(suffix, headers)

--- a/tests/test_api_class.py
+++ b/tests/test_api_class.py
@@ -66,18 +66,46 @@ class ApiObjectTest(unittest.TestCase):
         assert ao2.session is self.ao.session
 
     def test_compute_url(self):
+        # some value, doesn't really matter.
         suffix = 'unit/test/value'
-        expected = self.ao.compute_url() + '/' + suffix
+        expected = self.ao.baseurl + '/' + suffix
         assert self.ao.compute_url(suffix) == expected
+        # empty string and None should both return the root path.
+        rootdir = self.ao.baseurl
+        assert self.ao.compute_url() == rootdir
+        assert self.ao.compute_url('/') == rootdir
+        assert self.ao.compute_url('') == rootdir
+        assert self.ao.compute_url(None) == rootdir
 
     # We're not testing an exhaustive set of suffix patterns here because
     # that is already being done by the PathTracker unit tests.
     def test_cd(self):
+        # some value, doesn't really matter.
         suffix = 'unit/test/cd'
         expected = self.ao.compute_url() + '/' + suffix
         actual = self.ao.cd(suffix)
         assert actual == expected
         assert self.ao.compute_url() == expected
+        # check the root path works.
+        rootdir = self.ao.baseurl
+        self.ao.cd('/random/place1')
+        assert self.ao.compute_url() != rootdir
+        assert self.ao.cd('/') == rootdir
+        assert self.ao.compute_url() == rootdir
+        # no args should default to the root path.
+        self.ao.cd('/random/place0')
+        assert self.ao.compute_url() != rootdir
+        assert self.ao.cd() == rootdir
+        assert self.ao.compute_url() == rootdir
+        # empty string should default to the root path.
+        self.ao.cd('/random/place2')
+        assert self.ao.compute_url() != rootdir
+        assert self.ao.cd('') == rootdir
+        assert self.ao.compute_url() == rootdir
+        # None should default to the root path.
+        self.ao.cd('/random/place3')
+        assert self.ao.cd(None) == rootdir
+        assert self.ao.compute_url() == rootdir
 
     # We're not testing an exhaustive set of suffix patterns here because
     # that is already being done by the PathTracker unit tests.


### PR DESCRIPTION
The behavior for both of these was undefined in the past, though in
reality "cd" would cause an exception because it triesi to access [0]
and those values don't have one.

Explicitly code those to be synonyms for '/'. Also add unit tests
that these variants on root actually work.