### PR TITLE
Flesh out the REST methods of ApiWrapper

### DIFF
--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -309,3 +309,15 @@ class ApiWrapper(object):
 
     def get(self, suffix=None, headers=None):
         return self.api.get(suffix, headers=headers)
+
+    def post(self, suffix=None, headers=None, data=None, json=None):
+        return self.api.post(suffix, headers=headers, data=data, json=json)
+
+    def put(self, suffix=None, headers=None, data=None, json=None):
+        return self.api.put(suffix, headers=headers, data=data, json=json)
+
+    def delete(self, suffix=None, headers=None, data=None, json=None):
+        return self.api.delete(suffix, headers=headers, data=data, json=json)
+
+    def patch(self, suffix=None, headers=None, data=None, json=None):
+        return self.api.patch(suffix, headers=headers, data=data, json=json)

--- a/tests/test_api_class.py
+++ b/tests/test_api_class.py
@@ -57,8 +57,6 @@ class ApiObjectTest(unittest.TestCase):
             self.fake_auth.copy()
         )
         assert 'ApiObject' in str(self.ao)
-        self.awrapper = opsramp.base.ApiWrapper(self.ao, 'whatevs')
-        assert 'ApiWrapper' in str(self.awrapper)
 
     def test_shared_session(self):
         '''All clones should share the requests session'''
@@ -333,21 +331,4 @@ class ApiObjectTest(unittest.TestCase):
             expected = 'unit test patch result'
             m.patch(url, text=expected)
             actual = self.ao.patch()
-            assert actual == expected
-
-    # We're not testing an exhaustive set of suffix patterns here because
-    # that is already being done by the ApiObject unit tests. Just
-    # get() and get(something) is enough.
-    def test_wrapped_get(self):
-        with requests_mock.Mocker() as m:
-            url = self.awrapper.api.compute_url()
-            expected = 'unit test wrapped get result'
-            m.get(url, text=expected, complete_qs=True)
-            actual = self.awrapper.get()
-            assert actual == expected
-        with requests_mock.Mocker() as m:
-            suffix = 'some/where/random'
-            url = self.awrapper.api.compute_url(suffix)
-            m.get(url, text=expected, complete_qs=True)
-            actual = self.awrapper.get(suffix)
             assert actual == expected

--- a/tests/test_api_wrapper.py
+++ b/tests/test_api_wrapper.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+#
+# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import unittest
+from mock import MagicMock
+
+from opsramp.base import ApiWrapper
+
+
+class ClassTest(unittest.TestCase):
+    def setUp(self):
+        self.mock_ao = MagicMock()
+        self.mock_ao.clone.return_value = self.mock_ao
+        self.testobj = ApiWrapper(self.mock_ao)
+
+    def test_str(self):
+        assert 'ApiWrapper' in str(self.testobj)
+
+    def test_get(self):
+        ut_hdrs = {'fake-header': 'fake-value'}
+        expected = 'unit test get result'
+        self.mock_ao.get.return_value = expected
+
+        suffix = 'milk'
+        # default headers
+        actual = self.testobj.get(suffix)
+        self.mock_ao.get.assert_called_with(suffix, headers=None)
+        assert actual == expected
+        # specific headers
+        actual = self.testobj.get(suffix, headers=ut_hdrs)
+        self.mock_ao.get.assert_called_with(suffix, headers=ut_hdrs)
+        assert actual == expected
+
+    def four_variants(self, suffix, test_fn, mock_ao_fn):
+        ut_hdrs = {'fake-header': 'fake-value'}
+        ut_text = 'some unit test string'
+        ut_json = {'id': 'unit test'}
+        expected = 'unit test result'
+        mock_ao_fn.return_value = expected
+
+        # all defaults
+        actual = test_fn()
+        mock_ao_fn.assert_called_with(
+            None, headers=None,
+            data=None, json=None
+        )
+
+        # with suffix
+        actual = test_fn(suffix)
+        mock_ao_fn.assert_called_with(
+            suffix, headers=None,
+            data=None, json=None
+        )
+        # specific headers
+        actual = test_fn(suffix, headers=ut_hdrs)
+        mock_ao_fn.assert_called_with(
+            suffix, headers=ut_hdrs,
+            data=None, json=None
+        )
+        assert actual == expected
+        # specific text body
+        actual = test_fn(suffix, data=ut_text)
+        mock_ao_fn.assert_called_with(
+            suffix, headers=None,
+            data=ut_text, json=None
+        )
+        assert actual == expected
+        # specific json body
+        actual = test_fn(suffix, json=ut_json)
+        mock_ao_fn.assert_called_with(
+            suffix, headers=None,
+            data=None, json=ut_json
+        )
+        assert actual == expected
+
+    def test_post(self):
+        self.four_variants(
+            'eggs',
+            self.testobj.post,
+            self.mock_ao.post
+        )
+
+    def test_put(self):
+        self.four_variants(
+            'flour',
+            self.testobj.put,
+            self.mock_ao.put
+        )
+
+    def test_delete(self):
+        self.four_variants(
+            'sultanas',
+            self.testobj.delete,
+            self.mock_ao.delete
+        )
+
+    def test_patch(self):
+        self.four_variants(
+            'meat',
+            self.testobj.patch,
+            self.mock_ao.patch
+        )


### PR DESCRIPTION
This base class should provide boilerplate versions of the standard
REST methods so that subclasses can just use those if they don't need
anything special.

Also moved the ApiWrapper unit tests into their own file because we're
expanding the number of them now.