### PR TITLE
Remove the need for urllib3 1.26+

### DIFF
--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -57,7 +57,11 @@ class Helpers(object):
         # urllib3 does not retry on POST by default, but we want to iff the
         # return status is 429 rate limiting, on the assumption that this
         # means the POST did not happen and is therefore safe to retry.
-        http_verbs = set(Helpers.retryclass.DEFAULT_ALLOWED_METHODS)
+        try:
+            http_verbs = set(Helpers.retryclass.DEFAULT_ALLOWED_METHODS)
+        except AttributeError:
+            # it has a different name in older versions of urllib3
+            http_verbs = set(Helpers.retryclass.DEFAULT_METHOD_WHITELIST)
         http_verbs.add('POST')
         retry = Helpers.create_retry_handler(
             retries=7,

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-requests>=2.25.0
-simplejson>=3.17.2
-urllib3>=1.26.0
+requests
+simplejson
+urllib3


### PR DESCRIPTION
This is a very new version of urllib3 and even Ubuntu 20.04 doesn't
provide it by default. We're only using the DEFAULT_ALLOWED_METHODS
attribute and we can easily fallback to an older attribute that was
present in earlier urllib3 versions. The older one is deprecated and
will go away in the future, so I am leaving the new name in place
as the first choice if it exists.