### PR TITLE
Unit test mock: instead of https: or http:

### DIFF
--- a/tests/test_api_class.py
+++ b/tests/test_api_class.py
@@ -46,7 +46,7 @@ class FakeResp(object):
 
 class ApiObjectTest(unittest.TestCase):
     def setUp(self):
-        self.fake_url = 'http://api.example.com'
+        self.fake_url = 'mock://api.example.com'
         self.fake_token = 'ffffffffffffffff'
         self.fake_auth = {
             'Authorization': 'Bearer %s' % self.fake_token,

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -23,15 +23,20 @@ import opsramp.binding
 
 class BindingTest(unittest.TestCase):
     def setUp(self):
-        endpoint = 'https://api.example.com'
+        endpoint = 'mock://api.example.com'
         key = 'opensesame'
         secret = 'thereisnospoon'
         token = 'fake-unit-test-token'
+
+        url = endpoint + '/auth/oauth/token'
         hshake = 'grant_type=client_credentials&client_id=%s&client_secret=%s'
+        expected_send = hshake % (key, secret)
+        expected_receive = {'access_token': token}
+        expected_auth = {
+            'Authorization': 'Bearer ' + token,
+            'Accept': 'application/json,application/xml'
+        }
         with requests_mock.Mocker() as m:
-            url = endpoint + '/auth/oauth/token'
-            expected_send = hshake % (key, secret)
-            expected_receive = {'access_token': token}
             adapter = m.post(url, json=expected_receive, complete_qs=True)
             self.ormp = opsramp.binding.connect(
                 endpoint,
@@ -40,7 +45,10 @@ class BindingTest(unittest.TestCase):
             )
             assert m.call_count == 1
             assert adapter.last_request.text == expected_send
-        assert type(self.ormp) is opsramp.binding.Opsramp
+            assert type(self.ormp) is opsramp.binding.Opsramp
+            assert self.ormp.auth == expected_auth
+
+    def test_str(self):
         assert 'Opsramp' in str(self.ormp)
 
     def test_config(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -82,7 +82,7 @@ class StaticsTest(unittest.TestCase):
 
 class ApiTest(unittest.TestCase):
     def setUp(self):
-        fake_url = 'https://api.example.com'
+        fake_url = 'mock://api.example.com'
         fake_token = 'unit-test-fake-token'
         self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
 

--- a/tests/test_devmgmt.py
+++ b/tests/test_devmgmt.py
@@ -21,9 +21,9 @@ import requests_mock
 import opsramp.binding
 
 
-class DevmgmtText(unittest.TestCase):
+class DevmgmtTest(unittest.TestCase):
     def setUp(self):
-        fake_url = 'https://api.example.com'
+        fake_url = 'mock://api.example.com'
         fake_token = 'unit-test-fake-token'
         self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
 
@@ -52,7 +52,7 @@ class DevmgmtText(unittest.TestCase):
             thisid = 111111
             expected = {'id': thisid}
             url = group.api.compute_url()
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.create(definition=expected)
             assert actual == expected
 
@@ -60,7 +60,7 @@ class DevmgmtText(unittest.TestCase):
             thisid = 123456
             expected = {'id': thisid}
             url = group.api.compute_url(thisid)
-            m.put(url, json=expected)
+            m.put(url, json=expected, complete_qs=True)
             actual = group.update(uuid=thisid, definition=expected)
             assert actual == expected
 
@@ -68,7 +68,7 @@ class DevmgmtText(unittest.TestCase):
             thisid = 789012
             expected = {'id': thisid}
             url = group.api.compute_url('%s/action/run' % thisid)
-            m.get(url, json=expected)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.run(uuid=thisid)
             assert actual == expected
 
@@ -76,7 +76,7 @@ class DevmgmtText(unittest.TestCase):
             thisid = 345678
             expected = {'id': thisid}
             url = group.api.compute_url(thisid)
-            m.delete(url, json=expected)
+            m.delete(url, json=expected, complete_qs=True)
             actual = group.delete(uuid=thisid)
             assert actual == expected
 
@@ -101,7 +101,7 @@ class DevmgmtText(unittest.TestCase):
             thisid = 111111
             expected = {'id': thisid}
             url = group.api.compute_url()
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.create(definition=expected)
             assert actual == expected
 
@@ -109,7 +109,7 @@ class DevmgmtText(unittest.TestCase):
             thisid = 123456
             expected = {'id': thisid}
             url = group.api.compute_url()
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.update(definition=expected)
             assert actual == expected
 
@@ -117,7 +117,7 @@ class DevmgmtText(unittest.TestCase):
             thisid = 789012
             expected = {'id': thisid}
             url = group.api.compute_url('action/scan/%s' % thisid)
-            m.get(url, json=expected)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.rescan(uuid=thisid)
             assert actual == expected
 
@@ -125,7 +125,7 @@ class DevmgmtText(unittest.TestCase):
             thisid = 345678
             expected = {'id': thisid}
             url = group.api.compute_url(thisid)
-            m.delete(url, json=expected)
+            m.delete(url, json=expected, complete_qs=True)
             actual = group.delete(uuid=thisid)
             assert actual == expected
 
@@ -136,7 +136,7 @@ class DevmgmtText(unittest.TestCase):
             thisid = 111111
             expected = {'id': thisid}
             url = group.api.compute_url()
-            m.get(url, json=expected)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.get()
             assert actual == expected
 
@@ -144,7 +144,7 @@ class DevmgmtText(unittest.TestCase):
             thisid = 222222
             expected = {'id': thisid}
             url = group.api.compute_url()
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.create(definition=expected)
             assert actual == expected
 
@@ -152,7 +152,7 @@ class DevmgmtText(unittest.TestCase):
             thisid = 123456
             expected = {'id': thisid}
             url = group.api.compute_url(thisid)
-            m.get(url, json=expected)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.get(uuid=thisid)
             assert actual == expected
 
@@ -160,7 +160,7 @@ class DevmgmtText(unittest.TestCase):
             thisid = 789012
             expected = {'id': thisid}
             url = group.api.compute_url('%s/minimal' % thisid)
-            m.get(url, json=expected)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.get(uuid=thisid, minimal=True)
             assert actual == expected
 
@@ -168,7 +168,7 @@ class DevmgmtText(unittest.TestCase):
             thisid = 345678
             expected = {'id': thisid}
             url = group.api.compute_url(thisid)
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.update(uuid=thisid, definition=expected)
             assert actual == expected
 
@@ -176,6 +176,6 @@ class DevmgmtText(unittest.TestCase):
             thisid = 901234
             expected = {'id': thisid}
             url = group.api.compute_url(thisid)
-            m.delete(url, json=expected)
+            m.delete(url, json=expected, complete_qs=True)
             actual = group.delete(uuid=thisid)
             assert actual == expected

--- a/tests/test_escalations.py
+++ b/tests/test_escalations.py
@@ -23,7 +23,7 @@ import opsramp.binding
 
 class ApiTest(unittest.TestCase):
     def setUp(self):
-        fake_url = 'http://api.example.com'
+        fake_url = 'mock://api.example.com'
         fake_token = 'unit-test-fake-token'
         self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
 

--- a/tests/test_first_response.py
+++ b/tests/test_first_response.py
@@ -23,7 +23,7 @@ import opsramp.binding
 
 class ApiTest(unittest.TestCase):
     def setUp(self):
-        fake_url = 'http://api.example.com'
+        fake_url = 'mock://api.example.com'
         fake_token = 'unit-test-fake-token'
         self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
 

--- a/tests/test_globalconfig.py
+++ b/tests/test_globalconfig.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import opsramp.binding
 
 class GlobalConfigTest(unittest.TestCase):
     def setUp(self):
-        fake_url = 'http://api.example.com'
+        fake_url = 'mock://api.example.com'
         fake_token = 'unit-test-fake-token'
         self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
         self.gconfig = self.ormp.config()
@@ -45,7 +45,7 @@ class GlobalConfigTest(unittest.TestCase):
                 expected = ['unit', 'test']
                 expected.extend(suffix.split('/'))
                 assert expected
-                m.get(url, json=expected)
+                m.get(url, json=expected, complete_qs=True)
                 actual = fn()
                 assert actual == expected
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -26,7 +26,7 @@ from opsramp.integrations import Instances
 
 class InstancesTest(unittest.TestCase):
     def setUp(self):
-        fake_url = 'http://api.example.com'
+        fake_url = 'mock://api.example.com'
         fake_token = 'unit-test-fake-token'
         self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
 

--- a/tests/test_kb.py
+++ b/tests/test_kb.py
@@ -23,7 +23,7 @@ import opsramp.binding
 
 class KBtest(unittest.TestCase):
     def setUp(self):
-        fake_url = 'http://api.example.com'
+        fake_url = 'mock://api.example.com'
         fake_token = 'unit-test-fake-token'
         self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
 
@@ -47,7 +47,7 @@ class CategoriesTest(KBtest):
         expected = {'id': 345678}
         with requests_mock.Mocker() as m:
             assert expected
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.create(definition=expected)
         assert actual == expected
 
@@ -58,7 +58,7 @@ class CategoriesTest(KBtest):
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
             assert expected
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.update(uuid=thisid, definition=expected)
         assert actual == expected
 
@@ -69,7 +69,7 @@ class CategoriesTest(KBtest):
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
             assert expected
-            m.delete(url, json=expected)
+            m.delete(url, json=expected, complete_qs=True)
             actual = group.delete(uuid=thisid)
         assert actual == expected
 
@@ -80,7 +80,7 @@ class CategoriesTest(KBtest):
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
             assert expected
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.restore(uuid=thisid)
         assert actual == expected
 
@@ -90,7 +90,7 @@ class CategoriesTest(KBtest):
         url = group.api.compute_url(thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            m.get(url, json=expected)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.get(thisid)
             assert actual == expected
 
@@ -102,7 +102,7 @@ class CategoriesTest(KBtest):
         expected = ['unit', 'test', 'list']
         with requests_mock.Mocker() as m:
             assert expected
-            m.get(url, json=expected)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.children(thisid)
         assert actual == expected
 
@@ -114,7 +114,7 @@ class CategoriesTest(KBtest):
         expected = ['unit', 'test', 'list']
         with requests_mock.Mocker() as m:
             assert expected
-            m.get(url, json=expected)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.search(pattern=pattern)
         assert actual == expected
 
@@ -131,7 +131,7 @@ class ArticlesTest(KBtest):
         expected = {'id': 345678}
         with requests_mock.Mocker() as m:
             assert expected
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.create(definition=expected)
         assert actual == expected
 
@@ -142,7 +142,7 @@ class ArticlesTest(KBtest):
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
             assert expected
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.update(uuid=thisid, definition=expected)
         assert actual == expected
 
@@ -153,7 +153,7 @@ class ArticlesTest(KBtest):
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
             assert expected
-            m.delete(url, json=expected)
+            m.delete(url, json=expected, complete_qs=True)
             actual = group.delete(uuid=thisid)
         assert actual == expected
 
@@ -164,7 +164,7 @@ class ArticlesTest(KBtest):
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
             assert expected
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.share(uuid=thisid, definition=expected)
         assert actual == expected
 
@@ -174,7 +174,7 @@ class ArticlesTest(KBtest):
         url = group.api.compute_url(thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            m.get(url, json=expected)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.get(thisid)
             assert actual == expected
 
@@ -184,7 +184,7 @@ class ArticlesTest(KBtest):
         url = group.api.compute_url('%s/comments/' % thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            m.get(url, json=expected)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.comments(thisid)
             assert actual == expected
 
@@ -196,7 +196,7 @@ class ArticlesTest(KBtest):
         expected = ['unit', 'test', 'list']
         with requests_mock.Mocker() as m:
             assert expected
-            m.get(url, json=expected)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.search(pattern)
         assert actual == expected
 
@@ -213,7 +213,7 @@ class TemplatesTest(KBtest):
         expected = {'id': 345678}
         with requests_mock.Mocker() as m:
             assert expected
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.create(definition=expected)
         assert actual == expected
 
@@ -224,7 +224,7 @@ class TemplatesTest(KBtest):
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
             assert expected
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = group.update(uuid=thisid, definition=expected)
         assert actual == expected
 
@@ -235,7 +235,7 @@ class TemplatesTest(KBtest):
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
             assert expected
-            m.delete(url, json=expected)
+            m.delete(url, json=expected, complete_qs=True)
             actual = group.delete(uuid=thisid)
         assert actual == expected
 
@@ -245,7 +245,7 @@ class TemplatesTest(KBtest):
         url = group.api.compute_url(thisid)
         expected = {'id': thisid}
         with requests_mock.Mocker() as m:
-            m.get(url, json=expected)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.get(thisid)
             assert actual == expected
 
@@ -257,6 +257,6 @@ class TemplatesTest(KBtest):
         expected = ['unit', 'test', 'list']
         with requests_mock.Mocker() as m:
             assert expected
-            m.get(url, json=expected)
+            m.get(url, json=expected, complete_qs=True)
             actual = group.search(pattern=pattern)
         assert actual == expected

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -23,7 +23,7 @@ import opsramp.binding
 
 class Metrics(unittest.TestCase):
     def setUp(self):
-        fake_url = 'http://api.example.com'
+        fake_url = 'mock://api.example.com'
         fake_token = 'unit-test-fake-token'
         self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
 

--- a/tests/test_mgmt_profiles.py
+++ b/tests/test_mgmt_profiles.py
@@ -23,7 +23,7 @@ import opsramp.binding
 
 class ApiTest(unittest.TestCase):
     def setUp(self):
-        fake_url = 'http://api.example.com'
+        fake_url = 'mock://api.example.com'
         fake_token = 'unit-test-fake-token'
         self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -23,7 +23,7 @@ import opsramp.binding
 
 class MonitoringTest(unittest.TestCase):
     def setUp(self):
-        fake_url = 'http://api.example.com'
+        fake_url = 'mock://api.example.com'
         fake_token = 'unit-test-fake-token'
         self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -60,7 +60,7 @@ class StaticsTest(unittest.TestCase):
 
 class ApiTest(unittest.TestCase):
     def setUp(self):
-        fake_url = 'https://api.example.com'
+        fake_url = 'mock://api.example.com'
         fake_token = 'unit-test-fake-token'
         self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
 

--- a/tests/test_retry_logic.py
+++ b/tests/test_retry_logic.py
@@ -1,3 +1,20 @@
+#!/usr/bin/env python
+#
+# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
 import logging
 import socket
 import sys

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -23,7 +23,7 @@ import opsramp.binding
 
 class ApiTest(unittest.TestCase):
     def setUp(self):
-        fake_url = 'http://api.example.com'
+        fake_url = 'mock://api.example.com'
         fake_token = 'unit-test-fake-token'
         self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -175,7 +175,7 @@ class StaticsTest(unittest.TestCase):
 
 class ApiTest(unittest.TestCase):
     def setUp(self):
-        fake_url = 'https://api.example.com'
+        fake_url = 'mock://api.example.com'
         fake_token = 'unit-test-fake-token'
         self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
 
@@ -195,7 +195,7 @@ class ApiTest(unittest.TestCase):
         with requests_mock.Mocker() as m:
             # we will be doing two posts so mock both results now.
             url = group.api.compute_url()
-            m.post(url, [{'json': parent}, {'json': child}])
+            m.post(url, [{'json': parent}, {'json': child}], complete_qs=True)
 
             # Create a category with no parent ID specified
             actual = group.create(
@@ -217,7 +217,7 @@ class ApiTest(unittest.TestCase):
         expected = ''
         with requests_mock.Mocker() as m:
             url = category_group.api.compute_url(categoryID)
-            m.delete(url, text=expected)
+            m.delete(url, text=expected, complete_qs=True)
             actual = category_group.delete(uuid=categoryID)
             assert actual == expected
 
@@ -233,7 +233,7 @@ class ApiTest(unittest.TestCase):
 
         with requests_mock.Mocker() as m:
             url = category_group.api.compute_url()
-            m.put(url, json=expected)
+            m.put(url, json=expected, complete_qs=True)
             actual = category_group.update(categoryID, {
                 'name': updated_name
             })
@@ -246,7 +246,7 @@ class ApiTest(unittest.TestCase):
         assert expected
         with requests_mock.Mocker() as m:
             url = this1.api.compute_url()
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = this1.create(
                 definition=expected
             )
@@ -260,7 +260,7 @@ class ApiTest(unittest.TestCase):
         assert expected
         with requests_mock.Mocker() as m:
             url = this1.api.compute_url(scriptId)
-            m.post(url, json=expected)
+            m.post(url, json=expected, complete_qs=True)
             actual = this1.update(
                 uuid=scriptId, definition=expected
             )
@@ -273,6 +273,6 @@ class ApiTest(unittest.TestCase):
         expected = ''
         with requests_mock.Mocker() as m:
             url = this1.api.compute_url(scriptId)
-            m.delete(url, text=expected)
+            m.delete(url, text=expected, complete_qs=True)
             actual = this1.delete(uuid=scriptId)
             assert actual == expected

--- a/tests/test_service_maps.py
+++ b/tests/test_service_maps.py
@@ -23,7 +23,7 @@ import opsramp.binding
 
 class ApiTest(unittest.TestCase):
     def setUp(self):
-        fake_url = 'http://api.example.com'
+        fake_url = 'mock://api.example.com'
         fake_token = 'unit-test-fake-token'
         self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -23,7 +23,7 @@ import opsramp.binding
 
 class ApiTest(unittest.TestCase):
     def setUp(self):
-        fake_url = 'http://api.example.com'
+        fake_url = 'mock://api.example.com'
         fake_token = 'unit-test-fake-token'
         self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
 

--- a/tests/test_tenant.py
+++ b/tests/test_tenant.py
@@ -23,7 +23,7 @@ import opsramp.binding
 
 class TenantTest(unittest.TestCase):
     def setUp(self):
-        fake_url = 'https://api.example.com'
+        fake_url = 'mock://api.example.com'
         fake_token = 'unit-test-fake-token'
         self.ormp = opsramp.binding.Opsramp(fake_url, fake_token)
 
@@ -39,7 +39,7 @@ class TenantTest(unittest.TestCase):
         with requests_mock.Mocker() as m:
             url = self.client.api.compute_url('agents/deployAgentsScript')
             expected = 'unit test fake agent content'
-            m.get(url, text=expected)
+            m.get(url, text=expected, complete_qs=True)
             actual = self.client.get_agent_script()
             assert actual == expected
             assert m.call_count == 1


### PR DESCRIPTION
This seems to be best practice so we should follow it. This commit also
has minor changes to add complete_qs=True in a few places where it was
missing and also improves the binding.py unit tests.