### PR TITLE
Typo in API endpoint to retrieve K8S configuration

### DIFF
--- a/opsramp/integrations.py
+++ b/opsramp/integrations.py
@@ -79,7 +79,7 @@ class Instances(ORapi):
         self.creator_api.chroot('install')
 
     def get_kubernetes_configuration(self, uuid):
-        return self.api.get('%s/configFile/kubernetes' % uuid)
+        return self.api.get('%s/configFile/Kubernetes' % uuid)
 
     def create(self, type_name, definition):
         resp = self.creator_api.post(type_name, json=definition)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -71,8 +71,8 @@ class InstancesTest(unittest.TestCase):
         group = self.integs.instances()
         thisid = 123456
         expected = {'id': thisid}
-        with requests_mock.Mocker() as m:
-            url = group.api.compute_url('%s/configFile/kubernetes' % thisid)
+        with requests_mock.Mocker(case_sensitive=True) as m:
+            url = group.api.compute_url('%s/configFile/Kubernetes' % thisid)
             m.get(url, json=expected, complete_qs=True)
             actual = group.get_kubernetes_configuration(uuid=thisid)
             assert actual == expected


### PR DESCRIPTION
Capitalizing "K" in "Kubernetes" in API endpoint