### PR TITLE
Make unit test URLs mocks case-sensitive.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+#
+# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import requests_mock
+
+
+def pytest_runtest_setup(item):
+    # OpsRamp URLs are case-sensitive so enforce that in our mocks.
+    requests_mock.mock.case_sensitive = True

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -71,7 +71,7 @@ class InstancesTest(unittest.TestCase):
         group = self.integs.instances()
         thisid = 123456
         expected = {'id': thisid}
-        with requests_mock.Mocker(case_sensitive=True) as m:
+        with requests_mock.Mocker() as m:
             url = group.api.compute_url('%s/configFile/Kubernetes' % thisid)
             m.get(url, json=expected, complete_qs=True)
             actual = group.get_kubernetes_configuration(uuid=thisid)


### PR DESCRIPTION
OpsRamp URLs are case-sensitive so make the mocks in our unit tests
check for that. By default request_mock is case-insensitive and we
have to explicitly enable that.

conftest.py is the canonical filename that pytest reads at the start
of each run to provide a place to add hooks, so use it to implement
this.