### PR TITLE
Add "session" property to the ApiWrapper class

### DIFF
--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -150,8 +150,10 @@ class ApiObject(object):
             self.tracker = tracker
         else:
             self.tracker = PathTracker()
-
-        self.session = Helpers.session_add_retry_handler(session=session)
+        if session:
+            self.session = session
+        else:
+            self.session = Helpers.session_add_retry_handler()
 
     def __str__(self):
         return '%s "%s" "%s"' % (
@@ -320,6 +322,14 @@ class ApiWrapper(object):
 
     def __str__(self):
         return '%s %s' % (str(type(self)), self.api)
+
+    @property
+    def session(self):
+        return self.api.session
+
+    @session.setter
+    def session(self, value):
+        self.api.session = value
 
     def get(self, suffix=None, headers=None):
         return self.api.get(suffix, headers=headers)

--- a/samples/session_test.py
+++ b/samples/session_test.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+#
+# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import os
+import json
+import requests
+
+import opsramp.binding
+
+
+def connect():
+    url = os.environ['OPSRAMP_URL']
+    key = os.environ['OPSRAMP_KEY']
+    secret = os.environ['OPSRAMP_SECRET']
+    return opsramp.binding.connect(url, key, secret)
+
+
+def main():
+    ormp = connect()
+
+    # use a custom session with default parameters.
+    my_session = requests.session()
+    ormp.session = my_session
+
+    # simple demo that the custom session works.
+    assert ormp.session is my_session
+    global_cfg = ormp.config()
+    tzs = global_cfg.get_timezones()
+    print('[')
+    for t in tzs:
+        print('  ', json.dumps(t))
+    print(']')
+    # check that the custom session is still in use.
+    assert ormp.session is my_session
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api_wrapper.py
+++ b/tests/test_api_wrapper.py
@@ -30,6 +30,18 @@ class ClassTest(unittest.TestCase):
     def test_str(self):
         assert 'ApiWrapper' in str(self.testobj)
 
+    def test_session_property(self):
+        aw = self.testobj
+        original_session = aw.session
+        assert original_session
+        # test the setter and getter
+        fake_session = MagicMock()
+        aw.session = fake_session
+        assert aw.session == fake_session
+        # put the real one back
+        aw.session = original_session
+        assert aw.session == original_session
+
     def test_get(self):
         ut_hdrs = {'fake-header': 'fake-value'}
         expected = 'unit test get result'

--- a/tests/test_api_wrapper.py
+++ b/tests/test_api_wrapper.py
@@ -37,10 +37,10 @@ class ClassTest(unittest.TestCase):
         # test the setter and getter
         fake_session = MagicMock()
         aw.session = fake_session
-        assert aw.session == fake_session
+        assert aw.session is fake_session
         # put the real one back
         aw.session = original_session
-        assert aw.session == original_session
+        assert aw.session is original_session
 
     def test_get(self):
         ut_hdrs = {'fake-header': 'fake-value'}

--- a/tests/test_orapi.py
+++ b/tests/test_orapi.py
@@ -57,10 +57,10 @@ class ClassTest(unittest.TestCase):
         # test the setter and getter
         fake_session = MagicMock()
         aw.session = fake_session
-        assert aw.session == fake_session
+        assert aw.session is fake_session
         # put the real one back
         aw.session = original_session
-        assert aw.session == original_session
+        assert aw.session is original_session
 
     def test_get(self):
         hdrs = {'fake-header': 'fake-value'}

--- a/tests/test_orapi.py
+++ b/tests/test_orapi.py
@@ -47,6 +47,21 @@ class ClassTest(unittest.TestCase):
     def test_str(self):
         assert 'ORapi' in str(self.testobj)
 
+    def test_session_property(self):
+        # The session property is defined in the base class but we
+        # will unit test it here anyway, to make sure nobody changes
+        # the base class in a way that breaks us.
+        aw = self.testobj
+        original_session = aw.session
+        assert original_session
+        # test the setter and getter
+        fake_session = MagicMock()
+        aw.session = fake_session
+        assert aw.session == fake_session
+        # put the real one back
+        aw.session = original_session
+        assert aw.session == original_session
+
     def test_get(self):
         hdrs = {'fake-header': 'fake-value'}
         expected = 'unit test get result'


### PR DESCRIPTION
Allow the user to supply a customized requests session if they need to.
This is an advanced use case because in general we would not want the
caller to have to deal with the requests module directly; it's effectively
an implementation detail. However session objects do sometimes need to be
built specifically the use case in hand, so we should allow that.