### PR TITLE
Add --debug support to the samples

### DIFF
--- a/samples/apiget.py
+++ b/samples/apiget.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,21 +19,37 @@
 from __future__ import print_function
 import os
 import yaml
-import sys
 import logging
+import argparse
 
 import opsramp.binding
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    parser.add_argument(
+        'suffix',
+        type=str
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
-    logging.basicConfig()
-    logging.getLogger().setLevel(logging.DEBUG)
+    ns = parse_argv()
+    suffix = ns.suffix
 
     endpoint = os.environ['OPSRAMP_URL']
     key = os.environ['OPSRAMP_KEY']
     secret = os.environ['OPSRAMP_SECRET']
 
-    suffix = sys.argv[1]
     ormp = opsramp.binding.connect(endpoint, key, secret)
     resp = ormp.get(suffix)
     print(yaml.dump(resp, default_flow_style=False))

--- a/samples/apiget.py
+++ b/samples/apiget.py
@@ -36,14 +36,14 @@ def parse_argv():
         type=str
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
     ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
     suffix = ns.suffix
 
     endpoint = os.environ['OPSRAMP_URL']

--- a/samples/category_create.py
+++ b/samples/category_create.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,8 @@
 
 from __future__ import print_function
 import os
-import sys
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -30,12 +31,26 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
-def main():
-    if len(sys.argv) != 2:
-        print('usage: %s <new category name>' % sys.argv[0])
-        exit(2)
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    parser.add_argument(
+        'category',
+        type=str
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
 
-    new_category_name = sys.argv[1]
+
+def main():
+    ns = parse_argv()
+    new_category_name = ns.category
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/category_create.py
+++ b/samples/category_create.py
@@ -42,14 +42,14 @@ def parse_argv():
         type=str
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
     ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
     new_category_name = ns.category
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']

--- a/samples/category_list.py
+++ b/samples/category_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 
 from __future__ import print_function
 import os
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -29,7 +31,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()

--- a/samples/category_list.py
+++ b/samples/category_list.py
@@ -38,14 +38,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/category_tree.py
+++ b/samples/category_tree.py
@@ -38,14 +38,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/category_tree.py
+++ b/samples/category_tree.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 
 from __future__ import print_function
 import os
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -29,7 +31,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()

--- a/samples/client_create_json.py
+++ b/samples/client_create_json.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ from __future__ import print_function
 import os
 import sys
 import json
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -39,7 +41,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     partner_id = os.environ['OPSRAMP_TENANT_ID']
 
     jdata = json.load(sys.stdin)

--- a/samples/client_create_json.py
+++ b/samples/client_create_json.py
@@ -48,14 +48,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     partner_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/client_get.py
+++ b/samples/client_get.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@
 
 from __future__ import print_function
 import os
-import sys
 import json
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -31,11 +32,28 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
-def main():
-    partner_id = os.environ['OPSRAMP_TENANT_ID']
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    parser.add_argument(
+        'uuid',
+        type=str
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
 
-    assert len(sys.argv) == 2
-    uniqueId = sys.argv[1]
+
+def main():
+    ns = parse_argv()
+    uniqueId = ns.uuid
+
+    partner_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()
     partner = ormp.tenant(partner_id)

--- a/samples/client_get.py
+++ b/samples/client_get.py
@@ -43,14 +43,14 @@ def parse_argv():
         type=str
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
     ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
     uniqueId = ns.uuid
 
     partner_id = os.environ['OPSRAMP_TENANT_ID']

--- a/samples/client_list.py
+++ b/samples/client_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 
 from __future__ import print_function
 import os
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -29,7 +31,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     partner_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()

--- a/samples/client_list.py
+++ b/samples/client_list.py
@@ -38,14 +38,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     partner_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/country_list.py
+++ b/samples/country_list.py
@@ -39,14 +39,15 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+
     ormp = connect()
     global_cfg = ormp.config()
     clist = global_cfg.get_countries()

--- a/samples/country_list.py
+++ b/samples/country_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 from __future__ import print_function
 import os
 import json
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -30,7 +32,21 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
     ormp = connect()
     global_cfg = ormp.config()
     clist = global_cfg.get_countries()

--- a/samples/device_management_policies.py
+++ b/samples/device_management_policies.py
@@ -39,14 +39,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     partner_id = os.environ['OPSRAMP_TENANT_ID']
     dmp_name = os.environ['OPSRAMP_DMP_NAME']

--- a/samples/device_management_policies.py
+++ b/samples/device_management_policies.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 from __future__ import print_function
 import os
 import json
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -30,7 +32,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     partner_id = os.environ['OPSRAMP_TENANT_ID']
     dmp_name = os.environ['OPSRAMP_DMP_NAME']
 

--- a/samples/discovery_profile_create.py
+++ b/samples/discovery_profile_create.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 
 from __future__ import print_function
 import os
+import logging
+import argparse
 
 import opsramp.binding
 import opsramp.integrations
@@ -36,7 +38,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()

--- a/samples/discovery_profile_create.py
+++ b/samples/discovery_profile_create.py
@@ -45,14 +45,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/email_alerts_integration_create.py
+++ b/samples/email_alerts_integration_create.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 from __future__ import print_function
 import os
 import yaml
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -30,7 +32,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()

--- a/samples/email_alerts_integration_create.py
+++ b/samples/email_alerts_integration_create.py
@@ -39,14 +39,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/escalation_get.py
+++ b/samples/escalation_get.py
@@ -43,14 +43,14 @@ def parse_argv():
         type=str
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
     ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
     uniqueId = ns.uuid
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']

--- a/samples/escalation_get.py
+++ b/samples/escalation_get.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@
 
 from __future__ import print_function
 import os
-import sys
 import yaml
 import logging
+import argparse
 
 import opsramp.binding
 
@@ -32,11 +32,28 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
-def main():
-    tenant_id = os.environ['OPSRAMP_TENANT_ID']
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    parser.add_argument(
+        'uuid',
+        type=str
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
 
-    assert len(sys.argv) == 2
-    uniqueId = sys.argv[1]
+
+def main():
+    ns = parse_argv()
+    uniqueId = ns.uuid
+
+    tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     logging.basicConfig()
     logging.getLogger().setLevel(logging.DEBUG)

--- a/samples/escalation_list.py
+++ b/samples/escalation_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 from __future__ import print_function
 import os
 import yaml
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -30,7 +32,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()

--- a/samples/escalation_list.py
+++ b/samples/escalation_list.py
@@ -39,14 +39,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/first_response_create.py
+++ b/samples/first_response_create.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 from __future__ import print_function
 import os
 import yaml
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -30,7 +32,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()

--- a/samples/first_response_create.py
+++ b/samples/first_response_create.py
@@ -39,14 +39,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/first_response_delete.py
+++ b/samples/first_response_delete.py
@@ -43,14 +43,14 @@ def parse_argv():
         type=str
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
     ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
     uniqueId = ns.uuid
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']

--- a/samples/first_response_delete.py
+++ b/samples/first_response_delete.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@
 
 from __future__ import print_function
 import os
-import sys
 import yaml
 import logging
+import argparse
 
 import opsramp.binding
 
@@ -32,14 +32,28 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    parser.add_argument(
+        'uuid',
+        type=str
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    ns = parse_argv()
+    uniqueId = ns.uuid
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
-
-    assert len(sys.argv) == 2
-    uniqueId = sys.argv[1]
-
-    logging.basicConfig()
-    logging.getLogger().setLevel(logging.DEBUG)
 
     ormp = connect()
     tenant = ormp.tenant(tenant_id)

--- a/samples/first_response_detail.py
+++ b/samples/first_response_detail.py
@@ -43,14 +43,14 @@ def parse_argv():
         type=str
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
     ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
     uniqueId = ns.uuid
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']

--- a/samples/first_response_detail.py
+++ b/samples/first_response_detail.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@
 from __future__ import print_function
 import os
 import yaml
-import sys
+import logging
+import argparse
+
 import opsramp.binding
 
 
@@ -30,10 +32,28 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    parser.add_argument(
+        'uuid',
+        type=str
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    ns = parse_argv()
+    uniqueId = ns.uuid
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
-    assert len(sys.argv) == 2
-    uniqueId = sys.argv[1]
 
     ormp = connect()
     tenant = ormp.tenant(tenant_id)

--- a/samples/first_response_disable.py
+++ b/samples/first_response_disable.py
@@ -43,14 +43,14 @@ def parse_argv():
         type=str
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
     ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
     uniqueId = ns.uuid
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']

--- a/samples/first_response_disable.py
+++ b/samples/first_response_disable.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@
 
 from __future__ import print_function
 import os
-import sys
 import yaml
 import logging
+import argparse
 
 import opsramp.binding
 
@@ -32,14 +32,28 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    parser.add_argument(
+        'uuid',
+        type=str
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    ns = parse_argv()
+    uniqueId = ns.uuid
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
-
-    assert len(sys.argv) == 2
-    uniqueId = sys.argv[1]
-
-    logging.basicConfig()
-    logging.getLogger().setLevel(logging.DEBUG)
 
     ormp = connect()
     tenant = ormp.tenant(tenant_id)

--- a/samples/first_response_enable.py
+++ b/samples/first_response_enable.py
@@ -43,14 +43,14 @@ def parse_argv():
         type=str
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
     ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
     uniqueId = ns.uuid
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']

--- a/samples/first_response_enable.py
+++ b/samples/first_response_enable.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@
 
 from __future__ import print_function
 import os
-import sys
 import yaml
 import logging
+import argparse
 
 import opsramp.binding
 
@@ -32,14 +32,28 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    parser.add_argument(
+        'uuid',
+        type=str
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    ns = parse_argv()
+    uniqueId = ns.uuid
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
-
-    assert len(sys.argv) == 2
-    uniqueId = sys.argv[1]
-
-    logging.basicConfig()
-    logging.getLogger().setLevel(logging.DEBUG)
 
     ormp = connect()
     tenant = ormp.tenant(tenant_id)

--- a/samples/first_response_list.py
+++ b/samples/first_response_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 from __future__ import print_function
 import os
 import yaml
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -30,7 +32,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()

--- a/samples/first_response_list.py
+++ b/samples/first_response_list.py
@@ -39,14 +39,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/first_response_update.py
+++ b/samples/first_response_update.py
@@ -43,14 +43,14 @@ def parse_argv():
         type=str
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
     ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
     uniqueId = ns.uuid
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']

--- a/samples/first_response_update.py
+++ b/samples/first_response_update.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,9 @@
 from __future__ import print_function
 import os
 import yaml
-import sys
+import logging
+import argparse
+
 import opsramp.binding
 
 
@@ -30,11 +32,28 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
-def main():
-    tenant_id = os.environ['OPSRAMP_TENANT_ID']
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    parser.add_argument(
+        'uuid',
+        type=str
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
 
-    assert len(sys.argv) == 2
-    uniqueId = sys.argv[1]
+
+def main():
+    ns = parse_argv()
+    uniqueId = ns.uuid
+
+    tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()
     tenant = ormp.tenant(tenant_id)

--- a/samples/integration_get.py
+++ b/samples/integration_get.py
@@ -43,14 +43,14 @@ def parse_argv():
         type=str
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
     ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
     uniqueId = ns.uuid
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']

--- a/samples/integration_get.py
+++ b/samples/integration_get.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@
 
 from __future__ import print_function
 import os
-import sys
 import yaml
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -31,11 +32,28 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
-def main():
-    tenant_id = os.environ['OPSRAMP_TENANT_ID']
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    parser.add_argument(
+        'uuid',
+        type=str
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
 
-    assert len(sys.argv) == 2
-    uniqueId = sys.argv[1]
+
+def main():
+    ns = parse_argv()
+    uniqueId = ns.uuid
+
+    tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()
     tenant = ormp.tenant(tenant_id)

--- a/samples/integration_list.py
+++ b/samples/integration_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 
 from __future__ import print_function
 import os
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -29,7 +31,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()

--- a/samples/integration_list.py
+++ b/samples/integration_list.py
@@ -38,14 +38,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/metrics_get.py
+++ b/samples/metrics_get.py
@@ -43,14 +43,14 @@ def parse_argv():
         type=str
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
     ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
     qstring = ns.query
 
     ormp = connect()

--- a/samples/metrics_get.py
+++ b/samples/metrics_get.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@
 from __future__ import print_function
 import os
 import yaml
-import sys
 import logging
+import argparse
 
 import opsramp.binding
 
@@ -32,9 +32,26 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    parser.add_argument(
+        'query',
+        type=str
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
-    logging.basicConfig()
-    logging.getLogger().setLevel(logging.DEBUG)
+    ns = parse_argv()
+    qstring = ns.query
 
     ormp = connect()
     group = ormp.metrics()
@@ -42,7 +59,6 @@ def main():
     # examples of possible urls: (with correct client id)
     # 'tenants/client_1234/metrics/mysql.cluster.status/metricType'
     # 'search?tenant=client_1234&resource=abcdef&metric=mysql.cluster.status'
-    qstring = sys.argv[1]
     found = group.get(qstring)
     print(yaml.dump(found, default_flow_style=False))
 

--- a/samples/mgmt_profiles_list.py
+++ b/samples/mgmt_profiles_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 from __future__ import print_function
 import os
 import yaml
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -30,7 +32,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     partner_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()

--- a/samples/mgmt_profiles_list.py
+++ b/samples/mgmt_profiles_list.py
@@ -39,14 +39,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     partner_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/permission_sets_list.py
+++ b/samples/permission_sets_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 from __future__ import print_function
 import os
 import yaml
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -30,7 +32,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()

--- a/samples/permission_sets_list.py
+++ b/samples/permission_sets_list.py
@@ -39,14 +39,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/resources_create.py
+++ b/samples/resources_create.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 from __future__ import print_function
 import os
 import yaml
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -30,7 +32,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()

--- a/samples/resources_create.py
+++ b/samples/resources_create.py
@@ -39,14 +39,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/resources_get_templates.py
+++ b/samples/resources_get_templates.py
@@ -47,14 +47,14 @@ def parse_argv():
         type=str
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
     ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
     resource_id = ns.uuid
     pattern = ns.pattern
 

--- a/samples/resources_get_templates.py
+++ b/samples/resources_get_templates.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@
 
 from __future__ import print_function
 import os
-import sys
 import yaml
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -31,14 +32,37 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    parser.add_argument(
+        'uuid',
+        type=str
+    )
+    parser.add_argument(
+        'pattern',
+        type=str
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    ns = parse_argv()
+    resource_id = ns.uuid
+    pattern = ns.pattern
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()
     tenant = ormp.tenant(tenant_id)
 
-    resource_id = sys.argv[1]
-    pattern = sys.argv[2]
     resources = tenant.resources()
     resp = resources.get_templates(resource_id, pattern)
     print(yaml.dump(resp, default_flow_style=False))

--- a/samples/resources_list.py
+++ b/samples/resources_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 from __future__ import print_function
 import os
 import yaml
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -30,7 +32,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()

--- a/samples/resources_list.py
+++ b/samples/resources_list.py
@@ -39,14 +39,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/roles_list.py
+++ b/samples/roles_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 from __future__ import print_function
 import os
 import yaml
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -30,7 +32,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()

--- a/samples/roles_list.py
+++ b/samples/roles_list.py
@@ -39,14 +39,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/script_create.py
+++ b/samples/script_create.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,8 @@
 
 from __future__ import print_function
 import os
-import sys
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -28,6 +29,23 @@ def connect():
     key = os.environ['OPSRAMP_KEY']
     secret = os.environ['OPSRAMP_SECRET']
     return opsramp.binding.connect(url, key, secret)
+
+
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    parser.add_argument(
+        'uuid',
+        type=str
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
 
 
 def create_command_script(targetcat):
@@ -77,12 +95,10 @@ print('hello world')
 
 
 def main():
-    tenant_id = os.environ['OPSRAMP_TENANT_ID']
+    ns = parse_argv()
+    category_id = int(ns.uuid)
 
-    if len(sys.argv) != 2:
-        print('usage: %s <category id>' % sys.argv[0])
-        exit(2)
-    category_id = int(sys.argv[1])
+    tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()
     tenant = ormp.tenant(tenant_id)

--- a/samples/script_create.py
+++ b/samples/script_create.py
@@ -42,9 +42,6 @@ def parse_argv():
         type=str
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
@@ -96,6 +93,9 @@ print('hello world')
 
 def main():
     ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
     category_id = int(ns.uuid)
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']

--- a/samples/service_maps_create.py
+++ b/samples/service_maps_create.py
@@ -40,14 +40,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     ormp = connect()
     tnt = ormp.tenant(tnt_id)

--- a/samples/service_maps_create.py
+++ b/samples/service_maps_create.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@
 
 from __future__ import print_function
 import os
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -31,12 +33,25 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
-ormp = connect()
-tnt = ormp.tenant(tnt_id)
-service_maps = tnt.service_maps()
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
 
 
 def main():
+    parse_argv()
+
+    ormp = connect()
+    tnt = ormp.tenant(tnt_id)
+    service_maps = tnt.service_maps()
 
     top_level_json = [{
         "name": "Finance Inventory",

--- a/samples/service_maps_get.py
+++ b/samples/service_maps_get.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,10 +18,10 @@
 
 from __future__ import print_function
 import os
+import logging
+import argparse
 
 import opsramp.binding
-
-tnt_id = os.environ['OPSRAMP_TENANT_ID']
 
 
 def connect():
@@ -31,7 +31,20 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
-def walk(map):
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
+def walk(service_maps, map):
     if map['childType'] != 'SERVICE':
         # print("LEAF! %s %s" % (map['id'], map['name']))
         print("LEAF! %s" % map)
@@ -41,18 +54,21 @@ def walk(map):
         maps = service_maps.get(map['id'])
         if 'results' in maps:
             for submap in maps['results']:
-                walk(submap)
-
-
-ormp = connect()
-tnt = ormp.tenant(tnt_id)
-service_maps = tnt.service_maps()
+                walk(service_maps, submap)
 
 
 def main():
+    parse_argv()
+
+    tnt_id = os.environ['OPSRAMP_TENANT_ID']
+
+    ormp = connect()
+    tnt = ormp.tenant(tnt_id)
+
+    service_maps = tnt.service_maps()
     resp = service_maps.get()
     for map in resp['results']:
-        walk(map)
+        walk(service_maps, map)
 
 
 if __name__ == "__main__":

--- a/samples/service_maps_get.py
+++ b/samples/service_maps_get.py
@@ -38,9 +38,6 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
@@ -58,7 +55,10 @@ def walk(service_maps, map):
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     tnt_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/session_test.py
+++ b/samples/session_test.py
@@ -38,14 +38,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     ormp = connect()
 

--- a/samples/session_test.py
+++ b/samples/session_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ from __future__ import print_function
 import os
 import json
 import requests
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -29,7 +31,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     ormp = connect()
 
     # use a custom session with default parameters.

--- a/samples/site_get.py
+++ b/samples/site_get.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +18,9 @@
 
 from __future__ import print_function
 import os
-import sys
 import yaml
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -31,11 +32,28 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
-def main():
-    tnt_id = os.environ['OPSRAMP_TENANT_ID']
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    parser.add_argument(
+        'uuid',
+        type=str
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
 
-    assert len(sys.argv) == 2
-    uniqueId = sys.argv[1]
+
+def main():
+    ns = parse_argv()
+    uniqueId = ns.uuid
+
+    tnt_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()
     tnt = ormp.tenant(tnt_id)

--- a/samples/site_get.py
+++ b/samples/site_get.py
@@ -43,14 +43,14 @@ def parse_argv():
         type=str
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
     ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
     uniqueId = ns.uuid
 
     tnt_id = os.environ['OPSRAMP_TENANT_ID']

--- a/samples/site_list.py
+++ b/samples/site_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 from __future__ import print_function
 import os
 import yaml
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -30,7 +32,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 
     ormp = connect()

--- a/samples/site_list.py
+++ b/samples/site_list.py
@@ -39,14 +39,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     tenant_id = os.environ['OPSRAMP_TENANT_ID']
 

--- a/samples/timezone_list.py
+++ b/samples/timezone_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 from __future__ import print_function
 import os
 import json
+import logging
+import argparse
 
 import opsramp.binding
 
@@ -30,7 +32,22 @@ def connect():
     return opsramp.binding.connect(url, key, secret)
 
 
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+    return ns
+
+
 def main():
+    parse_argv()
+
     ormp = connect()
     global_cfg = ormp.config()
     tzs = global_cfg.get_timezones()

--- a/samples/timezone_list.py
+++ b/samples/timezone_list.py
@@ -39,14 +39,14 @@ def parse_argv():
         action='store_true'
     )
     ns = parser.parse_args()
-    if ns.debug:
-        logging.basicConfig()
-        logging.getLogger().setLevel(logging.DEBUG)
     return ns
 
 
 def main():
-    parse_argv()
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
 
     ormp = connect()
     global_cfg = ormp.config()


### PR DESCRIPTION
Use argparse to implement a --debug flag that enables Python DEBUG
logging which can be very useful as a learning tool for what is
going on under the hood, which is one of the points of these samples.

I have cut/paste the code into each one because I want each sample
file to stand alone and not have any dependencies.

While here, fix a few problems with the main() function in the
service map examples to make them match the others.