### PR TITLE
Remove support for Python 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # python-opsramp CircleCI 2.0 configuration file
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,38 +45,9 @@ jobs:
       - store_artifacts:
           path: htmlcov
           destination: coverage
-  unit_py27:
-    docker:
-      - image: circleci/python:2.7.15
-    working_directory: ~/repo
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-dependencies-py2-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
-            - v1-dependencies-py2-
-      - run:
-          name: install dependencies
-          command: |
-            python -m virtualenv venv2
-            . venv2/bin/activate
-            pip install -r requirements.txt -r test-requirements.txt
-      - save_cache:
-          paths:
-            - ./venv2
-          key: v1-dependencies-py2-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
-      - run:
-          name: run tests
-          command: |
-            . venv2/bin/activate
-            ./runtests.sh
-      - store_artifacts:
-          path: htmlcov
-          destination: coverage
 
 workflows:
   version: 2
   "CircleCI":
     jobs:
     - unit_py37
-    - unit_py27

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ TravisCI [![Build Status](https://travis-ci.org/HewlettPackard/python-opsramp.sv
 CircleCI [![CircleCI](https://circleci.com/gh/HewlettPackard/python-opsramp.svg?style=svg)](https://circleci.com/gh/HewlettPackard/python-opsramp)
 
 ## About
-This directory tree contains a Python module that provides a convenient way to
+This directory tree contains a Python 3 module that provides a convenient way to
 access the OpsRamp REST API programmatically. The OpsRamp API documentation is
 somewhat opaque and this binding hides some of the details for exactly that reason.
 I have also added "assert" statements in various places to guard against pitfalls
@@ -45,14 +45,6 @@ All functions in this binding return regular Python objects (not JSON strings).
 In general you will need to look at the OpsRamp API docs to see exactly what
 sort of object and/fields the response will contain; typically we return exactly
 what the API gave us, or an equivalent Python object if it returned JSON.
-
-### Runtime Environment
-This module is primarily designed for use on Python 3.
-
-Note that Python 2 formally went end-of-life at the end of 2019 and while this
-module currently still works on Python 2.7.18, we plan to stop supporting Python 2
-at the end of January 2021. Currently you will just get a deprecation
-warning but after that date it will not be installable on Python 2.
 
 ## Public Object Tree
 Following is a summary of the object tree currently available in this OpsRamp language binding. See

--- a/opsramp/__init__.py
+++ b/opsramp/__init__.py
@@ -13,12 +13,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import warnings
 import sys
-if sys.version_info < (3,):
-    warnings.warn(
-        "Python 2 reached the end of its life at the end of 2019.\n"
-        "Please move to Python 3 because this module will drop support "
-        "on {eod}.".format(
-            eod='31-Jan-2021'
-        ), DeprecationWarning)
+assert sys.version_info > (3,), "This module requires Python 3"

--- a/opsramp/api.py
+++ b/opsramp/api.py
@@ -6,7 +6,7 @@
 # OpsRamp-specific variant of ApiWrapper base class as a container for
 # some methods and helpers that are common to multiple parts of that API.
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import base64
 
 from opsramp.base import ApiWrapper

--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -20,17 +20,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import requests
 import logging
-try:
-    # Python 3
-    from urllib import parse as urlparse
-    from simplejson.errors import JSONDecodeError
-except ImportError:
-    # Python 2
-    import urlparse
-    JSONDecodeError = ValueError
+from urllib import parse as urlparse
+from simplejson.errors import JSONDecodeError
 
 
 LOG = logging.getLogger(__name__)

--- a/opsramp/binding.py
+++ b/opsramp/binding.py
@@ -5,7 +5,7 @@
 # binding.py
 # Defines the primary entry points for callers of this library.
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
 
 from opsramp.base import ApiObject
 from opsramp.api import ORapi

--- a/opsramp/cli.py
+++ b/opsramp/cli.py
@@ -3,7 +3,7 @@
 # A command line interface to OpsRamp that illustrates how to use
 # this language binding as well as being useful in its own right.
 #
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import json
 import argparse

--- a/opsramp/devmgmt.py
+++ b/opsramp/devmgmt.py
@@ -5,7 +5,7 @@
 # devmgmt.py
 # Device management classes.
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from opsramp.api import ORapi
 
 

--- a/opsramp/escalations.py
+++ b/opsramp/escalations.py
@@ -5,7 +5,7 @@
 # escalations.py
 # Classes dealing directly with OpsRamp Alert Escalation Policies.
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from opsramp.api import ORapi
 
 

--- a/opsramp/examples.py
+++ b/opsramp/examples.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 

--- a/opsramp/first_response.py
+++ b/opsramp/first_response.py
@@ -5,7 +5,7 @@
 # first_response.py
 # Classes dealing directly with OpsRamp First Response Policies.
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from opsramp.api import ORapi
 
 

--- a/opsramp/globalconfig.py
+++ b/opsramp/globalconfig.py
@@ -4,7 +4,7 @@
 #
 # globalconfig.py
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from opsramp.api import ORapi
 
 

--- a/opsramp/integrations.py
+++ b/opsramp/integrations.py
@@ -5,7 +5,7 @@
 # integrations.py
 # Classes related to Integrations.
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 
 from opsramp.api import ORapi

--- a/opsramp/kb.py
+++ b/opsramp/kb.py
@@ -6,7 +6,7 @@
 # Classes dealing directly with OpsRamp knowledge base categories
 # and articles.
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from opsramp.api import ORapi
 
 

--- a/opsramp/metrics.py
+++ b/opsramp/metrics.py
@@ -6,7 +6,7 @@
 # The OpsRamp metrics API is spread all over the place. This is a simple
 # initial class to expose the "get metric time series values" API.
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from opsramp.api import ORapi
 
 

--- a/opsramp/mgmt_profiles.py
+++ b/opsramp/mgmt_profiles.py
@@ -6,7 +6,7 @@
 # Classes dealing directly with OpsRamp Management Profiles.
 # The are used for interactions with gateway nodes.
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from opsramp.api import ORapi
 
 

--- a/opsramp/monitoring.py
+++ b/opsramp/monitoring.py
@@ -5,7 +5,7 @@
 # monitoring.py
 # Classes related to monitoring templates and similar things.
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from opsramp.api import ORapi
 
 

--- a/opsramp/msp.py
+++ b/opsramp/msp.py
@@ -5,7 +5,7 @@
 # msp.py
 # Classes related to partner-level actions.
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import datetime
 from opsramp.api import ORapi
 

--- a/opsramp/rba.py
+++ b/opsramp/rba.py
@@ -5,7 +5,7 @@
 # rba.py
 # Runbook Automation related classes
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
 
 from opsramp.api import ORapi
 

--- a/opsramp/resources.py
+++ b/opsramp/resources.py
@@ -5,7 +5,7 @@
 # resources.py
 # Resource classes.
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from opsramp.api import ORapi
 
 

--- a/opsramp/roles.py
+++ b/opsramp/roles.py
@@ -5,7 +5,7 @@
 # roles.py
 # Classes dealing directly with OpsRamp RBAC.
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from opsramp.api import ORapi
 
 

--- a/opsramp/service_maps.py
+++ b/opsramp/service_maps.py
@@ -7,7 +7,7 @@
 # Service Maps are used to organise resources by any method and
 # create availability rules governing how they show problems.
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from opsramp.api import ORapi
 
 

--- a/opsramp/sites.py
+++ b/opsramp/sites.py
@@ -6,7 +6,7 @@
 # Classes dealing directly with OpsRamp Sites.
 # Sites are used to organise resources by geographical location.
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from opsramp.api import ORapi
 
 

--- a/opsramp/tenant.py
+++ b/opsramp/tenant.py
@@ -5,7 +5,7 @@
 # tenant.py
 # Classes dealing directly with OpsRamp Tenants.
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from __future__ import print_function
 
 from opsramp.api import ORapi
 import opsramp.rba

--- a/samples/apiget.py
+++ b/samples/apiget.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/category_create.py
+++ b/samples/category_create.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import logging
 import argparse

--- a/samples/category_list.py
+++ b/samples/category_list.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import logging
 import argparse

--- a/samples/category_tree.py
+++ b/samples/category_tree.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import logging
 import argparse

--- a/samples/client_create_json.py
+++ b/samples/client_create_json.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import sys
 import json

--- a/samples/client_get.py
+++ b/samples/client_get.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import json
 import logging

--- a/samples/client_list.py
+++ b/samples/client_list.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import logging
 import argparse

--- a/samples/country_list.py
+++ b/samples/country_list.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import json
 import logging

--- a/samples/device_management_policies.py
+++ b/samples/device_management_policies.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import json
 import logging

--- a/samples/discovery_profile_create.py
+++ b/samples/discovery_profile_create.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import logging
 import argparse

--- a/samples/email_alerts_integration_create.py
+++ b/samples/email_alerts_integration_create.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/escalation_get.py
+++ b/samples/escalation_get.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/escalation_list.py
+++ b/samples/escalation_list.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/first_response_create.py
+++ b/samples/first_response_create.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/first_response_delete.py
+++ b/samples/first_response_delete.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/first_response_detail.py
+++ b/samples/first_response_detail.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/first_response_disable.py
+++ b/samples/first_response_disable.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/first_response_enable.py
+++ b/samples/first_response_enable.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/first_response_list.py
+++ b/samples/first_response_list.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/first_response_update.py
+++ b/samples/first_response_update.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/integration_get.py
+++ b/samples/integration_get.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/integration_list.py
+++ b/samples/integration_list.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import logging
 import argparse

--- a/samples/metrics_get.py
+++ b/samples/metrics_get.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/mgmt_profiles_list.py
+++ b/samples/mgmt_profiles_list.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/permission_sets_list.py
+++ b/samples/permission_sets_list.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/resources_create.py
+++ b/samples/resources_create.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/resources_get_templates.py
+++ b/samples/resources_get_templates.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/resources_list.py
+++ b/samples/resources_list.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/roles_list.py
+++ b/samples/roles_list.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/script_create.py
+++ b/samples/script_create.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import logging
 import argparse

--- a/samples/service_maps_create.py
+++ b/samples/service_maps_create.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import logging
 import argparse

--- a/samples/service_maps_get.py
+++ b/samples/service_maps_get.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import logging
 import argparse

--- a/samples/session_test.py
+++ b/samples/session_test.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import json
 import requests

--- a/samples/site_get.py
+++ b/samples/site_get.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/site_list.py
+++ b/samples/site_list.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import yaml
 import logging

--- a/samples/timezone_list.py
+++ b/samples/timezone_list.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import json
 import logging

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ license_files = LICENSE
 # support. Removing this line (or setting universal to 0) will prevent
 # bdist_wheel from trying to make a universal wheel. For more see:
 # https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels
-universal=1
+universal=0
 
 [flake8]
 exclude=.git,__pycache__,.tox,.eggs,*.egg,venv,venv2,venv3

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ with open('requirements.txt', 'r') as fh:
 
 setuptools.setup(
     name='python-opsramp',
-    python_requires='>=2.7',
+    python_requires='>=3.6',
     setup_requires=['setuptools_scm'],
     use_scm_version=True,
     author='HPE GreenLake CSO',
@@ -45,7 +45,6 @@ setuptools.setup(
         'Development Status :: 4 - Beta ',
         'Intended Audience :: Developers',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 2.7',
         'License :: OSI Approved :: Apache Software License',
         'Topic :: Software Development :: Libraries',
         'Operating System :: OS Independent',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import requests_mock
 
 

--- a/tests/test_api_class.py
+++ b/tests/test_api_class.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 from requests import codes as http_status
 from mock import MagicMock

--- a/tests/test_api_wrapper.py
+++ b/tests/test_api_wrapper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 from mock import MagicMock
 

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import requests_mock
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import datetime
 import requests_mock

--- a/tests/test_devmgmt.py
+++ b/tests/test_devmgmt.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import requests_mock
 

--- a/tests/test_escalations.py
+++ b/tests/test_escalations.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import requests_mock
 

--- a/tests/test_first_response.py
+++ b/tests/test_first_response.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import requests_mock
 

--- a/tests/test_globalconfig.py
+++ b/tests/test_globalconfig.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import requests_mock
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import base64
 import copy
 import unittest

--- a/tests/test_kb.py
+++ b/tests/test_kb.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import requests_mock
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import requests_mock
 

--- a/tests/test_mgmt_profiles.py
+++ b/tests/test_mgmt_profiles.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import requests_mock
 

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import requests_mock
 

--- a/tests/test_orapi.py
+++ b/tests/test_orapi.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import base64
 from mock import MagicMock

--- a/tests/test_pathtracker.py
+++ b/tests/test_pathtracker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 
 from opsramp.base import PathTracker

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import requests_mock
 

--- a/tests/test_retry_logic.py
+++ b/tests/test_retry_logic.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import logging
 import socket
 import sys
@@ -27,13 +26,8 @@ import requests
 
 from opsramp.base import ApiObject, ApiWrapper
 
-try:
-    from http.server import BaseHTTPRequestHandler, HTTPServer
-    from io import StringIO
-except ImportError:
-    # Python 2.x support
-    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer  # noqa
-    from StringIO import StringIO  # noqa
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from io import StringIO
 
 # Define a list of "canned" responses here. These are used to test the retry
 # capability of the API client, so that when faced with a response containing a

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import requests_mock
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import requests_mock
 

--- a/tests/test_service_maps.py
+++ b/tests/test_service_maps.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import requests_mock
 

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import requests_mock
 

--- a/tests/test_tenant.py
+++ b/tests/test_tenant.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import unittest
 import requests_mock
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 [tox]
-envlist = py27,py3
+envlist = py3
 
 [testenv]
 deps = -rrequirements.txt


### PR DESCRIPTION
Python 2 went end-of-life at the end of 2019 and we have given it more
than a year of support after that but now we need to move on and empower
ourselves to use new features of Python3 that don't exist on 2 and so
previously we would avoid because of compatibility requirements.