### PR TITLE
Get Training File API support:

### DIFF
--- a/opsramp/first_response.py
+++ b/opsramp/first_response.py
@@ -61,3 +61,6 @@ class ModelTraining(ORapi):
 
     def file_upload(self, payload, files):
         return self.api.post('files', data=payload, files=files)
+
+    def get_training_file(self):
+        return self.api.get('files')

--- a/samples/first_response_list_training_file.py
+++ b/samples/first_response_list_training_file.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+#
+# Exercise the opsramp module as an illustration of how to use it.
+#
+# (c) Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+import os
+
+import opsramp.binding
+import yaml
+
+
+def connect():
+    url = os.environ['OPSRAMP_URL']
+    key = os.environ['OPSRAMP_KEY']
+    secret = os.environ['OPSRAMP_SECRET']
+    return opsramp.binding.connect(url, key, secret)
+
+
+def parse_argv():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d', '--debug',
+        action='store_true'
+    )
+    ns = parser.parse_args()
+    return ns
+
+
+def main():
+    ns = parse_argv()
+    if ns.debug:
+        logging.basicConfig()
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    tenant_id = os.environ['OPSRAMP_TENANT_ID']
+
+    ormp = connect()
+
+    tenant = ormp.tenant(tenant_id)
+
+    group = tenant.model_training()
+    found = group.get_training_file()
+
+    print(found['totalResults'],
+          'first response policies in tenant', tenant_id)
+    print(yaml.dump(found['results'], default_flow_style=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/first_response_list_training_file.py
+++ b/samples/first_response_list_training_file.py
@@ -56,10 +56,12 @@ def main():
     group = tenant.model_training()
     found = group.get_training_file()
 
-    print(found['totalResults'],
-          'first response policies in tenant', tenant_id)
-    print(yaml.dump(found['results'], default_flow_style=False))
-
+    # There is only ever at most one result in the 'results'
+    # list returned.
+    if found['results']:
+        print(yaml.dump(found['results'], default_flow_style=False))
+    else:
+        print('no training file found in tenant.')
 
 if __name__ == "__main__":
     main()

--- a/samples/first_response_list_training_file.py
+++ b/samples/first_response_list_training_file.py
@@ -63,5 +63,6 @@ def main():
     else:
         print('no training file found in tenant.')
 
+
 if __name__ == "__main__":
     main()

--- a/tests/test_first_response.py
+++ b/tests/test_first_response.py
@@ -131,3 +131,26 @@ class ApiTest(unittest.TestCase):
                 m.post(url, text=expected, complete_qs=True)
                 actual = group.file_upload(data, file)
                 assert actual == expected
+
+    def test_get_training_file(self):
+        group = self.model_training
+        expected = {
+            "results": [
+                {
+                    "name": "sample"
+                }
+            ],
+            "totalResults": 1,
+            "orderBy": "createdTime",
+            "pageNo": 1,
+            "pageSize": 100,
+            "totalPages": 1,
+            "nextPage": False,
+            "previousPageNo": 0,
+            "descendingOrder": True
+        }
+        with requests_mock.Mocker() as m:
+            url = group.api.compute_url('files')
+            m.get(url, json=expected, complete_qs=True)
+            actual = group.get_training_file()
+            assert actual == expected


### PR DESCRIPTION
Add `get_training_file` ModelTraining API:
    
Add the API to check for the existence of a model training file.
There is only ever one training file result returned, though the API
returns the result(s) in a list of results format:
    
Example:
```json
{
    "results": [
        {
            "id": "1234",
            "name": "training_file.csv",
            "size": 260,
            "category": "ALERT_FIRST_RESPONSE_TRAINING",
            "mimeType": "text/csv",
            "expire": false,
            "createdTime": "2021-06-18T07:57:46+0000",
            "updatedTime": "2021-06-18T07:57:46+0000",
            "properties": {
                "inputColumns": [
                    "foo"
                ],
                "outputColumns": [
                    "bar",
                    "bazz"
                ]
            }
        }
    ],
    "totalResults": 1,
    "orderBy": "createdTime",
    "pageNo": 1,
    "pageSize": 100,
    "totalPages": 1,
    "nextPage": false,
    "previousPageNo": 0,
    "descendingOrder": true
}
```

Add a new sample under `samples/` demonstrating the usage of this GET
endpoint.
