### PR TITLE
OK is not the only HTTP success code.

### DIFF
--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -260,7 +260,8 @@ class ApiObject(object):
         return hdr
 
     def process_result(self, url, resp):
-        if resp.status_code != requests.codes.OK:
+        hstatus = int(resp.status_code)
+        if hstatus < 200 or hstatus >= 300:
             msg = '%s %s %s %s' % (
                 resp,
                 resp.request.method,


### PR DESCRIPTION
Anything in the range 200-299 is a successful result and in particular
POST operations often return http CREATED or NO_CONTENT if there is
nothing more to communicate except that the POST succeeded.

Also refactor the unit tests in this area slightly, they are a bit
old-fashioned in having long functions instead of several short ones
which are easier to spot in the output if they fail.