### PR TITLE
Rework and modernize packaging config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,17 @@
+# (c) Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+[flake8]
+exclude=.git,__pycache__,.tox,.eggs,*.egg,venv,venv2,venv3
+ignore=none
+max-line-length=132

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ somewhat opaque and this binding hides some of the details for exactly that reas
 I have also added "assert" statements in various places to guard against pitfalls
 that I ran into that are not obvious from the API docs.
 
+### Build
+This repo includes standard Python packaging using pyproject.toml and setuptools.
+Source and wheel distributions can be built using `python3 -m build` in the usual way.
+
 ### Scope
 The basic framework of this library is in place and the
 scope has increased incrementally over time. The supplied samples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+# (c) Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "setuptools_scm[toml]>=3.4"
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+# Including this section is equivalent to supplying use_scm_version=True
+# in setup.py.

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,18 +13,22 @@
 # limitations under the License.
 
 [metadata]
+name = python-opsramp
+author = HPE GreenLake SRE
+author_email = eemz@hpe.com
+description = Python language binding for the Opsramp API
+keywords = opsramp
+url = https://github.com/HewlettPackard/python-opsramp
+license = Apache 2.0
 license_files = LICENSE
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: Apache Software License
+    Topic :: Software Development :: Libraries
+    Operating System :: OS Independent
 
-[bdist_wheel]
-# This flag says to generate wheels that support both Python 2 and Python
-# 3. If your code will not run unchanged on both Python 2 and 3, you will
-# need to generate separate wheels for each Python version that you
-# support. Removing this line (or setting universal to 0) will prevent
-# bdist_wheel from trying to make a universal wheel. For more see:
-# https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels
-universal=0
-
-[flake8]
-exclude=.git,__pycache__,.tox,.eggs,*.egg,venv,venv2,venv3
-ignore=none
-max-line-length=132
+[options]
+packages = opsramp
+python_requires = >=3.6

--- a/setup.py
+++ b/setup.py
@@ -28,27 +28,8 @@ with open('requirements.txt', 'r') as fh:
             requirements.append(line)
 
 setuptools.setup(
-    name='python-opsramp',
-    python_requires='>=3.6',
-    setup_requires=['setuptools_scm'],
-    use_scm_version=True,
-    author='HPE GreenLake CSO',
-    author_email='eemz@hpe.com',
-    description='Python language binding for the Opsramp API',
     long_description=long_description,
     long_description_content_type=long_description_content_type,
-    keywords='opsramp',
-    url='https://github.com/HewlettPackard/python-opsramp',
-    license='Apache 2.0',
-    packages=setuptools.find_packages(exclude=['contrib', 'docs', 'tests']),
-    classifiers=[
-        'Development Status :: 4 - Beta ',
-        'Intended Audience :: Developers',
-        'Programming Language :: Python :: 3',
-        'License :: OSI Approved :: Apache Software License',
-        'Topic :: Software Development :: Libraries',
-        'Operating System :: OS Independent',
-    ],
     install_requires=requirements,
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
We don't need to support Python2 any more so move the packaging information
to a more modern style with the static requirements in setup.cfg and the
build requirements in pyproject.toml