### PR TITLE
Reorder our import statements to comply with flake8 rule

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,6 +13,7 @@
 # limitations under the License.
 [flake8]
 exclude=.git,__pycache__,.tox,.eggs,*.egg,venv,venv2,venv3
+import_order_style = google
 # Take the advice of the "black" code formatter which has 88
 # as its standard linewidth because 80 is too restrictive.
 max-line-length=88

--- a/opsramp/base.py
+++ b/opsramp/base.py
@@ -20,9 +20,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import requests
 import logging
 from urllib import parse as urlparse
+
+import requests
 from simplejson.errors import JSONDecodeError
 
 

--- a/opsramp/binding.py
+++ b/opsramp/binding.py
@@ -5,7 +5,7 @@
 # binding.py
 # Defines the primary entry points for callers of this library.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from opsramp.base import ApiObject
 from opsramp.api import ORapi
+from opsramp.base import ApiObject
 from opsramp.globalconfig import GlobalConfig
-from opsramp.tenant import Tenant
 from opsramp.metrics import MetricsApi
+from opsramp.tenant import Tenant
 
 
 def connect(url, key, secret):

--- a/opsramp/cli.py
+++ b/opsramp/cli.py
@@ -3,7 +3,7 @@
 # A command line interface to OpsRamp that illustrates how to use
 # this language binding as well as being useful in its own right.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import json
 import argparse
+import json
+import os
 
 import opsramp.binding
 

--- a/opsramp/examples.py
+++ b/opsramp/examples.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,11 +17,11 @@
 # limitations under the License.
 
 import os
-import yaml
 
 import opsramp.binding
-import opsramp.rba
 import opsramp.msp
+import opsramp.rba
+import yaml
 
 
 CATEGORY_NAME = 'python-opsramp test category'

--- a/opsramp/msp.py
+++ b/opsramp/msp.py
@@ -5,7 +5,7 @@
 # msp.py
 # Classes related to partner-level actions.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 # limitations under the License.
 
 import datetime
+
 from opsramp.api import ORapi
 
 

--- a/opsramp/tenant.py
+++ b/opsramp/tenant.py
@@ -5,7 +5,7 @@
 # tenant.py
 # Classes dealing directly with OpsRamp Tenants.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,19 +20,19 @@
 # limitations under the License.
 
 from opsramp.api import ORapi
-import opsramp.rba
+import opsramp.devmgmt
+import opsramp.escalations
+import opsramp.first_response
+import opsramp.integrations
+import opsramp.kb
+import opsramp.mgmt_profiles
 import opsramp.monitoring
 import opsramp.msp
-import opsramp.devmgmt
-import opsramp.integrations
-import opsramp.roles
-import opsramp.escalations
-import opsramp.mgmt_profiles
-import opsramp.sites
-import opsramp.service_maps
-import opsramp.kb
+import opsramp.rba
 import opsramp.resources
-import opsramp.first_response
+import opsramp.roles
+import opsramp.service_maps
+import opsramp.sites
 
 
 class Tenant(ORapi):

--- a/samples/apiget.py
+++ b/samples/apiget.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def parse_argv():

--- a/samples/category_create.py
+++ b/samples/category_create.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
 

--- a/samples/category_list.py
+++ b/samples/category_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
 

--- a/samples/category_tree.py
+++ b/samples/category_tree.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
 

--- a/samples/client_create_json.py
+++ b/samples/client_create_json.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
+import argparse
 import json
 import logging
-import argparse
+import os
+import sys
 
 import opsramp.binding
 

--- a/samples/client_get.py
+++ b/samples/client_get.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+import argparse
 import json
 import logging
-import argparse
+import os
 
 import opsramp.binding
 

--- a/samples/client_list.py
+++ b/samples/client_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
 

--- a/samples/country_list.py
+++ b/samples/country_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+import argparse
 import json
 import logging
-import argparse
+import os
 
 import opsramp.binding
 

--- a/samples/device_management_policies.py
+++ b/samples/device_management_policies.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+import argparse
 import json
 import logging
-import argparse
+import os
 
 import opsramp.binding
 

--- a/samples/discovery_profile_create.py
+++ b/samples/discovery_profile_create.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
 import opsramp.integrations

--- a/samples/email_alerts_integration_create.py
+++ b/samples/email_alerts_integration_create.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/escalation_get.py
+++ b/samples/escalation_get.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/escalation_list.py
+++ b/samples/escalation_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/first_response_create.py
+++ b/samples/first_response_create.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/first_response_delete.py
+++ b/samples/first_response_delete.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/first_response_detail.py
+++ b/samples/first_response_detail.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/first_response_disable.py
+++ b/samples/first_response_disable.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/first_response_enable.py
+++ b/samples/first_response_enable.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/first_response_file_upload.py
+++ b/samples/first_response_file_upload.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,11 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
+
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/first_response_list.py
+++ b/samples/first_response_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/first_response_model_training.py
+++ b/samples/first_response_model_training.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/first_response_update.py
+++ b/samples/first_response_update.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/integration_get.py
+++ b/samples/integration_get.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/integration_list.py
+++ b/samples/integration_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
 

--- a/samples/metrics_get.py
+++ b/samples/metrics_get.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/mgmt_profiles_list.py
+++ b/samples/mgmt_profiles_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/permission_sets_list.py
+++ b/samples/permission_sets_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/resources_create.py
+++ b/samples/resources_create.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/resources_get_templates.py
+++ b/samples/resources_get_templates.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/resources_list.py
+++ b/samples/resources_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/roles_list.py
+++ b/samples/roles_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/script_create.py
+++ b/samples/script_create.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
 

--- a/samples/service_maps_create.py
+++ b/samples/service_maps_create.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
 

--- a/samples/service_maps_get.py
+++ b/samples/service_maps_get.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
 

--- a/samples/session_test.py
+++ b/samples/session_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import json
-import requests
-import logging
 import argparse
+import json
+import logging
+import os
 
 import opsramp.binding
+import requests
 
 
 def connect():

--- a/samples/site_get.py
+++ b/samples/site_get.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/site_list.py
+++ b/samples/site_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import yaml
-import logging
 import argparse
+import logging
+import os
 
 import opsramp.binding
+import yaml
 
 
 def connect():

--- a/samples/timezone_list.py
+++ b/samples/timezone_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+import argparse
 import json
 import logging
-import argparse
+import os
 
 import opsramp.binding
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 flake8
+flake8-import-order
 coverage
 pytest
 mock

--- a/tests/test_api_class.py
+++ b/tests/test_api_class.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,16 +15,15 @@
 # limitations under the License.
 
 import unittest
-from requests import codes as http_status
-from mock import MagicMock
-import requests_mock
 
+from mock import MagicMock
+import opsramp.base
+from requests import codes as http_status
+import requests_mock
 # Note we are deliberately using simplejson (instead of json) because
 # that's what the requests module uses and we want to raise the same
 # types of exceptions, not exceptions from the generic "json" module.
 import simplejson
-
-import opsramp.base
 
 
 class FakeResp(object):

--- a/tests/test_api_wrapper.py
+++ b/tests/test_api_wrapper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 import unittest
-from mock import MagicMock
 
+from mock import MagicMock
 from opsramp.base import ApiWrapper
 
 

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 import unittest
-import requests_mock
 
 import opsramp.binding
+import requests_mock
 
 
 class BindingTest(unittest.TestCase):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
 import datetime
-import requests_mock
+import unittest
 
-from opsramp.msp import Clients
 import opsramp.binding
+from opsramp.msp import Clients
+import requests_mock
 
 
 class StaticsTest(unittest.TestCase):

--- a/tests/test_devmgmt.py
+++ b/tests/test_devmgmt.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 import unittest
-import requests_mock
 
 import opsramp.binding
+import requests_mock
 
 
 class DevmgmtTest(unittest.TestCase):

--- a/tests/test_escalations.py
+++ b/tests/test_escalations.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 import unittest
-import requests_mock
 
 import opsramp.binding
+import requests_mock
 
 
 class ApiTest(unittest.TestCase):

--- a/tests/test_first_response.py
+++ b/tests/test_first_response.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 import unittest
-import requests_mock
+
 import opsramp.binding
+import requests_mock
 
 
 class ApiTest(unittest.TestCase):

--- a/tests/test_globalconfig.py
+++ b/tests/test_globalconfig.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 import unittest
-import requests_mock
 
 import opsramp.binding
+import requests_mock
 
 
 class GlobalConfigTest(unittest.TestCase):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@
 import base64
 import copy
 import unittest
-import requests_mock
 
 import opsramp.binding
 from opsramp.integrations import Instances
+import requests_mock
 
 
 class InstancesTest(unittest.TestCase):

--- a/tests/test_kb.py
+++ b/tests/test_kb.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 import unittest
-import requests_mock
 
 import opsramp.binding
+import requests_mock
 
 
 class KBtest(unittest.TestCase):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 import unittest
-import requests_mock
 
 import opsramp.binding
+import requests_mock
 
 
 class Metrics(unittest.TestCase):

--- a/tests/test_mgmt_profiles.py
+++ b/tests/test_mgmt_profiles.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 import unittest
-import requests_mock
 
 import opsramp.binding
+import requests_mock
 
 
 class ApiTest(unittest.TestCase):

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 import unittest
-import requests_mock
 
 import opsramp.binding
+import requests_mock
 
 
 class MonitoringTest(unittest.TestCase):

--- a/tests/test_orapi.py
+++ b/tests/test_orapi.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,11 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import os
 import unittest
-import base64
-from mock import MagicMock
 
+from mock import MagicMock
 from opsramp.api import ORapi
 
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
 # limitations under the License.
 
 import unittest
-import requests_mock
 
 import opsramp.binding
 import opsramp.resources
+import requests_mock
 
 
 class StaticsTest(unittest.TestCase):

--- a/tests/test_retry_logic.py
+++ b/tests/test_retry_logic.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,20 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import contextmanager
+from copy import deepcopy
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from io import StringIO
 import logging
 import socket
 import sys
-import unittest
-from contextlib import contextmanager
-from copy import deepcopy
 from threading import Thread
-
-import requests
+import unittest
 
 from opsramp.base import ApiObject, ApiWrapper
-
-from http.server import BaseHTTPRequestHandler, HTTPServer
-from io import StringIO
+import requests
 
 # Define a list of "canned" responses here. These are used to test the retry
 # capability of the API client, so that when faced with a response containing a

--- a/tests/test_role.py
+++ b/tests/test_role.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 import unittest
-import requests_mock
 
 import opsramp.binding
+import requests_mock
 
 
 class ApiTest(unittest.TestCase):

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,11 +15,11 @@
 # limitations under the License.
 
 import unittest
-import requests_mock
 
 from opsramp.api import ORapi
-from opsramp.rba import Category
 import opsramp.binding
+from opsramp.rba import Category
+import requests_mock
 
 
 class StaticsTest(unittest.TestCase):

--- a/tests/test_service_maps.py
+++ b/tests/test_service_maps.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 import unittest
-import requests_mock
 
 import opsramp.binding
+import requests_mock
 
 
 class ApiTest(unittest.TestCase):

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 import unittest
-import requests_mock
 
 import opsramp.binding
+import requests_mock
 
 
 class ApiTest(unittest.TestCase):

--- a/tests/test_tenant.py
+++ b/tests/test_tenant.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 import unittest
-import requests_mock
 
 import opsramp.binding
+import requests_mock
 
 
 class TenantTest(unittest.TestCase):


### PR DESCRIPTION
We don't have to support Python 2 any more so let's reorder our import
statements to comply with a standard flake8 model. No actual code changes
despite the size of the commit.