### PR TITLE
Add yamllint to CI checks

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,19 @@
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+
+extends: default
+
+rules:
+  # 120 chars is a better standard than the 80 character limit.
+  line-length:
+    max: 120
+  # We really don't care about new lines at the ends of yaml files.
+  new-line-at-end-of-file: disable
+  # Don't need to start the yaml files with ---
+  document-start: disable
+  # We are fine with having a space buffer between braces and their content.
+  braces:
+    max-spaces-inside: 1
+  indentation:
+    spaces: consistent
+    indent-sequences: consistent
+    check-multi-line-strings: false

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 #
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+#
 # runtests.sh
 # This script runs the actual test commands and assumes that the required
 # packages are already installed. Installation of the packages is done
 # outside of this script using pip install -r test-requirements.txt and
 # that command is already folded into our tox.ini
-#
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,7 +26,8 @@ if [ -n "$windowsnewlines" ]; then
   echo 'Windows newlines are not allowed in Python sources in this repo' >&2
   exit 1
 fi
-flake8
+yamllint .
+flake8 .
 coverage run --include='opsramp/*' -m pytest -vvv
 coverage report
 coverage html

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -18,3 +18,4 @@ coverage
 pytest
 mock
 requests_mock
+yamllint

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
-# (c) Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
We have only one or two YAML files in the repo right now but that
could change so let's introduce yamllint while things are clean to
keep them that way.