### PR TITLE
Explicitly include requirements.txt in the sdist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,7 @@
 # start this container interactively and use -e to pass in the environment
 # variables it needs (see cli.py). Once inside you can run commands like:
 #
-# ormpcli tenant rba categories
-# ormpcli tenant agent script
-# ormpcli tenant monitoring templates
-#
-# (c) Copyright 2019-2020 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,16 +17,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.7.5-slim as build
-RUN pip install --upgrade pip
+FROM python:3.7.5-slim as baseimage
+
+FROM baseimage as build
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
     && rm -rf /var/lib/apt/lists/*
-# use artifact from previous build step in pipeline
-ADD . /build
-RUN pip install /build
+RUN pip install --upgrade pip
+RUN pip install --upgrade build
+WORKDIR /build
+ADD . .
+RUN rm -rf build dist *.egg-info .eggs
+RUN pip install .
 
-FROM python:3.7.5-slim as prod
+FROM baseimage as prod
 LABEL description="OpsRamp CLI"
 LABEL maintainer "HPE GreenLake CSO <eemz@hpe.com>"
 COPY --from=build /usr/local /usr/local

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+# (c) Copyright 2022 Hewlett Packard Enterprise Development LP
+include requirements.txt


### PR DESCRIPTION
Add MANIFEST.in to explicitly include requirements.txt in the sdist.

That file is definitely needed by setup.py but there is no explicit
instruction to add it to the source distro in the existing codebase.
It's not clear why it's being added at the moment on most machines
regardless. But I would prefer to make it explicit anyway.