### PR TITLE
Test build using both PEP517 and old-school setuptools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,12 +28,19 @@ jobs:
             python3 -m venv venv2
             . venv2/bin/activate
             python3 -m pip install --upgrade pip
-            pip install --upgrade build flake8 tox yamllint
+            pip install --upgrade build wheel flake8 tox yamllint
       - run:
-          name: build distribution packages
+          name: PEP517 build
           command: |
             . venv2/bin/activate
+            rm -rf python_opsramp.egg-info
             python3 -m build
+      - run:
+          name: setuptools build as used by tox
+          command: |
+            . venv2/bin/activate
+            rm -rf python_opsramp.egg-info
+            python3 setup.py sdist bdist_wheel
   unit_py37:
     docker:
       - image: cimg/python:3.7.5


### PR DESCRIPTION
The setuptools build is still important because tox uses it by default.