### PR TITLE
Update yamllint rules for GH Actions.

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -3,17 +3,15 @@
 extends: default
 
 rules:
-  # 120 chars is a better standard than the 80 character limit.
   line-length:
     max: 120
-  # We really don't care about new lines at the ends of yaml files.
-  new-line-at-end-of-file: disable
-  # Don't need to start the yaml files with ---
   document-start: disable
-  # We are fine with having a space buffer between braces and their content.
-  braces:
-    max-spaces-inside: 1
+  new-line-at-end-of-file: disable
   indentation:
     spaces: consistent
     indent-sequences: consistent
     check-multi-line-strings: false
+  # Allow syntax deviations that are used by the GitHub Actions wizard.
+  truthy: disable
+  brackets:
+    max-spaces-inside: 1


### PR DESCRIPTION
The GitHub Actions wizard uses some syntax features in its autogenerated files
that red flag some of the yamllint default rules, so we need to turn those off.