### PR TITLE
Fix list2ormp() assertion failure on empty search response

### DIFF
--- a/opsramp/resources.py
+++ b/opsramp/resources.py
@@ -29,6 +29,12 @@ def list2ormp(result_obj):
         assert "results" in result_obj
         assert "totalResults" in result_obj
         return result_obj
+
+    # If there are no results, the response may be completely
+    # empty, which maps to `result_obj` being an empty string here.
+    if result_obj == "":
+        result_obj = []
+
     # Wrap it up in a fake of the typical OpsRamp results struct
     # so that callers don't have to special case it.
     assert isinstance(result_obj, list)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -43,6 +43,19 @@ class StaticsTest(unittest.TestCase):
         result = opsramp.resources.list2ormp(list_form)
         assert result == canonical_form
 
+    def test_list2ormp_empty_conversion(self):
+        result = opsramp.resources.list2ormp("")
+        assert result == {
+            "totalResults": 0,
+            "pageSize": 0,
+            "totalPages": 1,
+            "pageNo": 1,
+            "previousPageNo": 0,
+            "nextPage": False,
+            "descendingOrder": False,
+            "results": [],
+        }
+
     def test_list2ormp_invalid(self):
         bad_ones = (
             3.14159,


### PR DESCRIPTION
Search api endpoints can return an empty response, as distinct from a json response containing no results.

This results in an assertion failure as described in #127

Handle this in `list2ormp()` by converting the empty response to an empty list, and thence to an 'empty response' struct.

Resolves #127