### PR TITLE
Run GitHub action on push only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,12 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-name: GitHub Actions
+name: Test head
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
     branches: [ master ]
 
   workflow_dispatch:


### PR DESCRIPTION
There's no value in running this against unmerged PRs right now because
the code in this action will always run against the current branch head
not the change that is being proposed, so it's pointless.