### PR TITLE
Add "tenancy" to auth url in binding.py

### DIFF
--- a/opsramp/binding.py
+++ b/opsramp/binding.py
@@ -27,7 +27,7 @@ from opsramp.tenant import Tenant
 
 
 def connect(url, key, secret):
-    auth_url = url + "/auth/oauth/token"
+    auth_url = url + "/tenancy/auth/oauth/token"
     auth_hdrs = {
         "Content-Type": "application/x-www-form-urlencoded",
         "Accept": "application/json,application/xml",

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -27,7 +27,7 @@ class BindingTest(unittest.TestCase):
         secret = "thereisnospoon"
         token = "fake-unit-test-token"
 
-        url = endpoint + "/auth/oauth/token"
+        url = endpoint + "/tenancy/auth/oauth/token"
         hshake = "grant_type=client_credentials&client_id=%s&client_secret=%s"
         expected_send = hshake % (key, secret)
         expected_receive = {"access_token": token}


### PR DESCRIPTION
The auth url has changed in recent OpsRamp versions, adding the concept of tenancy, so change to cope with that.