### PR TITLE
Remove "<", ">" from default `uninstallReason`

### DIFF
--- a/opsramp/integrations.py
+++ b/opsramp/integrations.py
@@ -84,7 +84,7 @@ class Instances(ORapi):
         resp = self.creator_api.post(type_name, json=definition)
         return resp
 
-    def delete(self, uuid, uninstall_reason="<Not specified>"):
+    def delete(self, uuid, uninstall_reason="Not specified"):
         json_payload = {"uninstallReason": uninstall_reason}
         return self.api.delete(suffix=uuid, json=json_payload)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -128,7 +128,7 @@ class InstancesTest(unittest.TestCase):
 
         # Test that the delete function inserts a default reason
         # if we don't provide one.
-        expected_send = {"uninstallReason": "<Not specified>"}
+        expected_send = {"uninstallReason": "Not specified"}
         with requests_mock.Mocker() as m:
             adapter = m.delete(url, json=expected_response, complete_qs=True)
             actual_response = group.delete(uuid=thisid)

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -48,7 +48,7 @@ class StaticsTest(unittest.TestCase):
                 name="pname",
                 description="pdesc",
                 datatype="STRING",
-                optional=True
+                optional=True,
                 # deliberately missing default value
             )
 


### PR DESCRIPTION
Remove "<", ">" from default `uninstallReason`

The OpsRamp API actively rejects an `uninstallReason` that contains the characters "<", or ">". Remove those character to make the default operation valid.

Both forms have been verified using Postman:
- `"<Not specified>"` - is rejected
- `"Not specified"` - is accepted

- Fix associated unit test.

Drive-by:
- add another comma to make 'black' happy