### PR TITLE
2024 Dockerfile updates & Python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # python-opsramp CircleCI 2.0 configuration file
 #
-# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 #
 version: 2.1
 jobs:
-  packaging_py37:
+  packaging_py39:
     docker:
-      - image: cimg/python:3.7.5
+      - image: cimg/python:3.9.19
     working_directory: ~/repo
     steps:
       - checkout
@@ -41,9 +41,9 @@ jobs:
             . venv2/bin/activate
             rm -rf python_opsramp.egg-info
             python3 -m build
-  unit_py37:
+  unit_py39:
     docker:
-      - image: cimg/python:3.7.5
+      - image: cimg/python:3.9.19
     working_directory: ~/repo
     steps:
       - checkout
@@ -67,5 +67,5 @@ workflows:
   version: 2
   "CircleCI":
     jobs:
-      - unit_py37
-      - packaging_py37
+      - unit_py39
+      - packaging_py39

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # start this container interactively and use -e to pass in the environment
 # variables it needs (see cli.py). Once inside you can run commands like:
 #
-# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM python:3.7.5-slim as baseimage
+FROM python:3.9.19-slim AS baseimage
 
-FROM baseimage as build
+FROM baseimage AS build
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
     && rm -rf /var/lib/apt/lists/*
@@ -30,9 +30,9 @@ ADD . .
 RUN rm -rf build dist *.egg-info .eggs
 RUN pip install .
 
-FROM baseimage as prod
+FROM baseimage AS prod
 LABEL description="OpsRamp CLI"
-LABEL maintainer "HPE GreenLake CSO <eemz@hpe.com>"
+LABEL maintainer="HPE GreenLake CSO <eemz@hpe.com>"
 COPY --from=build /usr/local /usr/local
 
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Fix minor nitpicks that the current docker build code has with the Dockerfile contents. While we're in the area, move to Python 3.9 so that we are at least somewhat closer to current.