### PR TITLE
Fix articlesList bug, update sample

### DIFF
--- a/opsramp/kb.py
+++ b/opsramp/kb.py
@@ -6,7 +6,7 @@
 # Classes dealing directly with OpsRamp knowledge base categories
 # and articles.
 #
-# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ class KBarticles(ORapi):
         return self.api.delete("%s/delete" % uuid)
 
     def search(self, pattern=""):
-        suffix = "articles/search"
+        suffix = "articlesList"
         if pattern:
             suffix += "?" + pattern
         # weirdly, this call needs to be made at "kb" level

--- a/samples/kbcategory_list.py
+++ b/samples/kbcategory_list.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ def connect():
 def parse_argv():
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", "--debug", action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
     ns = parser.parse_args()
     return ns
 
@@ -48,24 +49,28 @@ def main():
     ormp = connect()
     tenant = ormp.tenant(tenant_id)
 
-    categs = tenant.kb().categories()
-    print(categs)
-    clist = categs.search()
-    print(clist)
+    kb = tenant.kb()
+    categs = kb.categories()
+    articles = kb.articles()
+
+    allcats = categs.search()
+    clist = allcats["results"]
+    print(f"{len(clist)} categories")
     # for each category
     for cdata in clist:
-        print("category", cdata["id"], cdata["name"])
-        thiscat = categs.category(cdata["id"])
-        # for each script in this category
-        for s in thiscat.get():
+        categ_id = cdata["id"]
+        categ_name = cdata["name"]
+        print("category", categ_id, f'"{categ_name}"')
+        # for each article in this category
+        alist = articles.search(f"categoryId={categ_id}")
+        for s in alist["results"]:
             print(
-                "... script",
+                ". article",
                 s["id"],
-                s["platforms"],
-                s["executionType"],
-                '"%s"' % s["name"],
-                '"%s"' % s["description"],
+                s["subject"],
             )
+            if ns.verbose:
+                print(f'.. content "{s["content"]}"')
 
 
 if __name__ == "__main__":

--- a/tests/test_kb.py
+++ b/tests/test_kb.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -191,7 +191,7 @@ class ArticlesTest(KBtest):
         group = self.articles
         pattern = "whatever"
         # searches happen at the "kb" level
-        url = self.kb.api.compute_url("articles/search?%s" % pattern)
+        url = self.kb.api.compute_url("articlesList?%s" % pattern)
         expected = ["unit", "test", "list"]
         with requests_mock.Mocker() as m:
             assert expected


### PR DESCRIPTION
I don't know if this changed on the OpsRamp side, or just has never worked. Either way "articles/search" is not correct it needs to be "articlesList". Fix that bug + unit test.

Also take the opportunity to make the sample that shows some basic information about the knowledge base work a bit better and show in particular how to reach the article content (which seems to be in HTML format though that's not stated in the OpsRamp API docs).