### PR TITLE
Make the OpsRamp api token available as a property

### DIFF
--- a/opsramp/binding.py
+++ b/opsramp/binding.py
@@ -5,7 +5,7 @@
 # binding.py
 # Defines the primary entry points for callers of this library.
 #
-# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ def connect(url, key, secret):
 
 
 class Opsramp(ORapi):
-    def __init__(self, url, token):
+    def __init__(self, url: str, token: str):
         self.auth = {
             "Authorization": "Bearer " + token,
             "Accept": "application/json,application/xml",
@@ -54,6 +54,16 @@ class Opsramp(ORapi):
 
     def __str__(self):
         return "%s %s" % (str(type(self)), self.api)
+
+    @property
+    def token(self) -> str:
+        hdr: str = self.auth.get("Authorization", "")
+        return hdr.partition(" ")[-1]
+
+    @token.setter
+    def token(self, newtok: str) -> str:
+        self.auth.update({"Authorization": f"Bearer {newtok}"})
+        return newtok
 
     def config(self):
         return GlobalConfig(self)

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ class BindingTest(unittest.TestCase):
             assert adapter.last_request.text == expected_send
             assert type(self.ormp) is opsramp.binding.Opsramp
             assert self.ormp.auth == expected_auth
+            assert self.ormp.token == token
 
     def test_str(self):
         assert "Opsramp" in str(self.ormp)
@@ -53,3 +54,13 @@ class BindingTest(unittest.TestCase):
     def test_tenant(self):
         obj = self.ormp.tenant("unit-test")
         assert "Tenant" in str(obj)
+
+    def test_token_property(self):
+        tok: str = self.ormp.token
+        assert tok
+        newtok: str = "horry patter"
+        assert tok != newtok
+        # now change it
+        self.ormp.token = newtok
+        assert self.ormp.token == newtok
+        assert self.ormp.auth["Authorization"] == "Bearer " + newtok


### PR DESCRIPTION
Make it possible for the caller to get direct access to the OpsRamp API token because we have encountered a few use cases in the field where this is needed and people have been using unsupported hacks to get to it. Provide an approved method to counter this.