### PR TITLE
Permissions in GHA main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # python-opsramp GitHub Actions file
 #
-# (c) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2022-2026 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 name: GitHub CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
CodeQL analysis that all GitHub Action files need an explicit permissions statement in them that allows them to do only the things that they need to do.