### PR TITLE
Not all integrations support Kubernetes GET

### DIFF
--- a/samples/integration_get.py
+++ b/samples/integration_get.py
@@ -2,7 +2,7 @@
 #
 # Exercise the opsramp module as an illustration of how to use it.
 #
-# (c) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (c) Copyright 2019-2026 Hewlett Packard Enterprise Development LP
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,9 +57,14 @@ def main():
     group.redact_response(resp)
     print(yaml.dump(resp, indent=2))
 
-    resp_config = group.get_kubernetes_configuration(uniqueId)
-    resp_list = list(yaml.load_all(resp_config, Loader=yaml.SafeLoader))
-    print(yaml.dump(resp_list, indent=2))
+    try:
+        resp_config = group.get_kubernetes_configuration(uniqueId)
+    except RuntimeError as e:
+        if "not supported" not in str(e):
+            raise
+    else:
+        resp_list = list(yaml.load_all(resp_config, Loader=yaml.SafeLoader))
+        print(yaml.dump(resp_list, indent=2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We have encountered this in the field and it makes sense because get_kubernetes_configuration is meaningless for some integrations, so let's tolerate that outcome and return without printing anything.