### PR TITLE
Rework the pip freeze in SBOM

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -45,14 +45,14 @@ jobs:
 
       - name: Freeze Active Environment
         run: |
-          pip freeze > exact-packages.txt
+          pip freeze --all | grep -v "file:" > frozen-packages.txt
 
       - name: Generate CycloneDX SBOM
         uses: anchore/sbom-action@v0.24.0
         env:
           SYFT_PYTHON_GUESS_UNPINNED_REQUIREMENTS: "true"
         with:
-          path: ./exact-packages.txt
+          path: ./frozen-packages.txt
           format: 'cyclonedx-json'
           output-file: 'sbom.cyclonedx.json'
 


### PR DESCRIPTION
Unfortunately we're having to iterate on the live code base to get the SBOM collection right, because the environment in which it runs is different than local workstation.