### PR TITLE
Place the frozen list in a subdir for SBOM

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Freeze Active Environment
         run: |
+          mkdir -pv frozen
           pip freeze --all | grep -v "file:" > frozen/requirements.txt
 
       - name: Generate CycloneDX SBOM

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.10'
+          cache: 'baseline'
 
       - name: Install dependencies
         run: |
@@ -45,14 +46,14 @@ jobs:
 
       - name: Freeze Active Environment
         run: |
-          pip freeze --all | grep -v "file:" > frozen-packages.txt
+          pip freeze --all | grep -v "file:" > frozen/requirements.txt
 
       - name: Generate CycloneDX SBOM
         uses: anchore/sbom-action@v0.24.0
         env:
           SYFT_PYTHON_GUESS_UNPINNED_REQUIREMENTS: "true"
         with:
-          path: frozen-packages.txt
+          path: frozen
           format: 'cyclonedx-json'
           output-file: 'sbom.cyclonedx.json'
 


### PR DESCRIPTION
I am more optimistic about this suggestion.

The sbom-action workflow expects to walk a directory tree looking for files that match one of its magic names. Give it what it wants.