### PR TITLE
don't cache pip state in GHA

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.10'
-          cache: 'baseline'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Maybe we'll add this later but for now we want to see the latest package versions as a test of our SBOM generation.