### PR TITLE
Cache python initial environment in SBOM action

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.10'
+          cache: 'pip'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
We don't need Github to download the early setup
file for the Python environment again everytime.